### PR TITLE
Made SQL migration task aware of output

### DIFF
--- a/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
@@ -52,3 +52,4 @@
   retries: 3
   delay: 5
   until: _ara_sql_migrations is succeeded
+  changed_when: _ara_sql_migrations['stdout'] is not search('No migrations to apply.')

--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -52,3 +52,5 @@
   retries: 3
   delay: 5
   until: _ara_sql_migrations is succeeded
+  register: _ara_sql_migrations
+  changed_when: _ara_sql_migrations['stdout'] is not search('No migrations to apply.')

--- a/roles/ara_api/tasks/database_engine/django.db.backends.sqlite3.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.sqlite3.yaml
@@ -28,3 +28,5 @@
     ARA_SETTINGS: "{{ ara_api_settings }}"
     PATH: "{{ path_with_virtualenv }}"
   command: ara-manage migrate
+  register: _ara_sql_migrations
+  changed_when: _ara_sql_migrations['stdout'] is not search('No migrations to apply.')


### PR DESCRIPTION
This PR enhances the tasks that run SQL migrations to only report changes if there are actual changes that have been applied.

The test is really simple, just check for the presence of 'No migrations to apply' in the stdout of the command. If it's found, no changes have been made.

This was the only task changing every day in my ARA reports, which bugged me ;-)