### PR TITLE
Added logic to also update the ARA packages to a specific version

### DIFF
--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -42,7 +42,7 @@ ara_api_venv_path: "{{ ara_api_root_dir }}/virtualenv"
 # How ARA will be installed
 # - source [default]: installs from a local or remote git repository
 # - distribution: installs from distribution packages, if available
-# - pypi [planned]: installs from pypi
+# - pypi : installs from pypi
 ara_api_install_method: source
 
 # When installing from source, the URL or filesystem path where the git source

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -2,9 +2,11 @@
 - name: Install required packages from Pypi
   pip:
     name: ara[server]
-    state: present
+    state: "{% if ara_api_version == 'latest' %}latest{% else %}present{% endif %}"
+    version: "{% if ara_api_version != 'latest' %}{{ ara_api_version }}{% else %}{{ omit }}{% endif %}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv
+  notify: restart ara-api
 
 - name: Prefix the virtualenv bin directory to PATH
   set_fact:

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -2,8 +2,8 @@
 - name: Install required packages from Pypi
   pip:
     name: ara[server]
-    state: "{% if ara_api_version == 'latest' %}latest{% else %}present{% endif %}"
-    version: "{% if ara_api_version != 'latest' %}{{ ara_api_version }}{% else %}{{ omit }}{% endif %}"
+    state: "{{ (ara_api_version == 'latest') | ternary('latest', 'present') }}"
+    version: "{{ (ara_api_version != 'latest') | ternary(ara_api_version, omit) }}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv
   notify: restart ara-api


### PR DESCRIPTION
When running with the pypi installation method, the tasks I made would only install ARA, but never update. Neither would it respect the ara_api_version variable and just do it's own thing.

This should fix that :-)