### PR TITLE
zuul: Add integration jobs back in

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,82 @@
+- job:
+    name: ara-role-integration-base
+    parent: base
+    allowed-projects:
+      - github.com/ansible-community/ara
+      - github.com/ansible-community/ara-collection
+    required-projects:
+      - github.com/ansible-community/ara
+      - github.com/ansible-community/ara-collection
+    files:
+      - ara/*
+      - playbooks/*
+      - roles/*
+      - tests/*
+      - .zuul.d/*
+      - manage.py
+      - setup.py
+      - setup.cfg
+      - requirements.txt
+      - test-requirements.txt
+      - README.md
+      - galaxy.yml
+    vars:
+      ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
+      ara_tests_ansible_name: "{{ ansible_user_dir }}/src/github.com/ansible/ansible"
+      ara_tests_ansible_version: null
+      ara_api_secure_logging: false
+    post-run: tests/zuul_post_logs.yaml
+
+- job:
+    name: ara-role-database-backends
+    parent: ara-role-integration-base
+    required-projects:
+      - github.com/ansible-community/ara
+      - github.com/ansible-community/ara-collection
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    pre-run: tests/zuul_pre_multinode_networking.yaml
+
+- job:
+    name: ara-role-api-postgresql
+    parent: ara-role-database-backends
+    nodeset: ara-database-server-multinode
+    description: |
+      Deploys the ARA API server on Ubuntu 18.04, Fedora 32 as well as CentOS 8
+      and tests it against a central PostgreSQL server installed on CentOS 8.
+      The job exercises the ara_api Ansible role, the ARA Ansible plugins, the
+      ARA API clients as well as the API itself.
+    run: tests/with_postgresql.yaml
+    post-run: tests/zuul_post_with_postgresql.yaml
+
+- job:
+    name: ara-role-api-mysql
+    parent: ara-role-database-backends
+    nodeset: ara-database-server-multinode
+    description: |
+      Deploys the ARA API server on Ubuntu 18.04, Fedora 32 as well as CentOS 8
+      and tests it against a central MySQL server installed on CentOS 8.
+      The job exercises the ara_api Ansible role, the ARA Ansible plugins, the
+      ARA API clients as well as the API itself.
+    run: tests/with_mysql.yaml
+    post-run: tests/zuul_post_with_mysql.yaml
+
+- job:
+    name: ara-role-api-distributed-sqlite
+    parent: ara-role-database-backends
+    nodeset: ara-multinode
+    description: |
+      Deploys the ARA API server on Ubuntu 18.04, Fedora 32 as well as CentOS 8
+      and tests it using the distributed sqlite database backend.
+    run: tests/with_distributed_sqlite.yaml
+
+# TODO: The job should build a package from current source and test that package
+# instead of the package in the stable distribution.
+- job:
+    name: ara-role-api-fedora-packages
+    parent: ara-role-integration-base
+    nodeset: ara-fedora-32
+    description: |
+      Deploys the ARA API server on Fedora 32 using distribution packages for
+      ARA and Ansible.
+    run: tests/with_fedora_packages.yaml

--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -1,0 +1,50 @@
+# Nodeset used to test instances of ARA API deployed on different operating
+# systems against MySQL and PostgreSQL simultaneously.
+- nodeset:
+    name: ara-database-server-multinode
+    nodes:
+      - name: database-server
+        label: centos-8-1vcpu
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: fedora-32
+        label: fedora-32-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
+    groups:
+      - name: ara-database-server
+        nodes:
+          - database-server
+      - name: ara-api-server
+        nodes:
+          - ubuntu-bionic
+          - fedora-32
+          - centos-8
+
+# Nodeset used to test instances of ARA API deployed on different operating
+# systems simultaneously.
+- nodeset:
+    name: ara-multinode
+    nodes:
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: fedora-32
+        label: fedora-32-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
+    groups:
+      - name: ara-api-server
+        nodes:
+          - ubuntu-bionic
+          - fedora-32
+          - centos-8
+
+- nodeset:
+    name: ara-fedora-32
+    nodes:
+      - name: fedora-32
+        label: fedora-32-1vcpu
+    groups:
+      - name: ara-api-server
+        nodes:
+          - fedora-32

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,7 +1,14 @@
 - project:
+    merge-mode: squash-merge
     check:
       jobs:
-        - noop
+        - ara-role-api-distributed-sqlite
+        - ara-role-api-mysql
+        - ara-role-api-postgresql
+        - ara-role-api-fedora-packages:
+            voting: false
     gate:
       jobs:
-        - noop
+        - ara-role-api-distributed-sqlite
+        - ara-role-api-mysql
+        - ara-role-api-postgresql

--- a/roles/ara_api/vars/CentOS.yaml
+++ b/roles/ara_api/vars/CentOS.yaml
@@ -23,6 +23,8 @@ ara_api_required_packages:
   - git
   - python3
   - policycoreutils-python-utils
+  # cronie provides crontab
+  - cronie
 
 ara_api_postgresql_packages:
   - postgresql

--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -25,6 +25,8 @@ ara_api_required_packages:
   - python3-virtualenv
   - python3-libselinux
   - policycoreutils-python-utils
+  # cronie provides crontab
+  - cronie
 
 ara_api_postgresql_packages:
   - postgresql

--- a/roles/ara_api/vars/Ubuntu.yaml
+++ b/roles/ara_api/vars/Ubuntu.yaml
@@ -29,6 +29,7 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-server-dev-10
+  - python3-dev
   - gcc
 
 ara_api_mysql_packages:


### PR DESCRIPTION
We removed them earlier to simplify the migration to another zuul
instance. The jobs are essentially the same but with slightly different
nodeset names and updated paths to the repositories.