### PR TITLE
Needs exact match to "/", proxy_to_app overrides "location /"

### DIFF
--- a/roles/ara_frontend_nginx/templates/ara-api.conf.j2
+++ b/roles/ara_frontend_nginx/templates/ara-api.conf.j2
@@ -13,7 +13,7 @@ server {
     error_log  /var/log/nginx/{{ ara_api_fqdn }}_error.log;
 
     # There's nothing at /, redirect it to the actual API for convenience
-    location / {
+    location = / {
       return 301 http://{{ ara_api_fqdn }}/api/v1/;
     }
 


### PR DESCRIPTION
ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#location