### PR TITLE
ara_api: Add missing dependency on python3-devel for Fedora

### DIFF
--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -31,6 +31,7 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
+  - python3-devel
   - gcc
 
 ara_api_mysql_packages:


### PR DESCRIPTION
We need python3-devel when using the postgresql driver to compile
psycopg when installing from pip.