### PR TITLE
WIP - Vendor ARA client libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # ansible-galaxy collection build generates .tar.gz files
 *.tar.gz
+.pyc
+__pycache__

--- a/plugins/action/ara_playbook.py
+++ b/plugins/action/ara_playbook.py
@@ -1,0 +1,102 @@
+#  Copyright (c) 2019 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.playbook.play import Play
+from ansible.plugins.action import ActionBase
+
+from ansible_collections.recordsansible.ara.plugins.module_utils import _utils as client_utils
+
+DOCUMENTATION = """
+---
+module: ara_playbook
+short_description: Retrieves either a specific playbook from ARA or the one currently running
+version_added: "2.9"
+author: "David Moreau-Simard <dmsimard@redhat.com>"
+description:
+    - Retrieves either a specific playbook from ARA or the one currently running
+options:
+    playbook_id:
+        description:
+            - id of the playbook to retrieve
+            - if not set, the module will use the ongoing playbook's id
+        required: false
+
+requirements:
+    - "python >= 3.5"
+    - "ara >= 1.4.0"
+"""
+
+EXAMPLES = """
+- name: Get a specific playbook
+  ara_playbook:
+    playbook_id: 5
+  register: playbook_query
+
+- name: Get current playbook by not specifying a playbook id
+  ara_playbook:
+  register: playbook_query
+
+- name: Do something with the playbook
+  debug:
+    msg: "Playbook report: http://ara_api/playbook/{{ playbook_query.playbook.id | string }}.html"
+"""
+
+RETURN = """
+playbook:
+    description: playbook object returned by the API
+    returned: on success
+    type: dict
+"""
+
+
+class ActionModule(ActionBase):
+    """ Retrieves either a specific playbook from ARA or the one currently running """
+
+    TRANSFERS_FILES = False
+    VALID_ARGS = frozenset(("playbook_id"))
+
+    def __init__(self, *args, **kwargs):
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self.client = client_utils.active_client()
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        for arg in self._task.args:
+            if arg not in self.VALID_ARGS:
+                result = {"failed": True, "msg": "{0} is not a valid option.".format(arg)}
+                return result
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        playbook_id = self._task.args.get("playbook_id", None)
+        if playbook_id is None:
+            # Retrieve the playbook id by working our way up from the task to find
+            # the play uuid. Once we have the play uuid, we can find the playbook.
+            parent = self._task
+            while not isinstance(parent._parent._play, Play):
+                parent = parent._parent
+
+            play = self.client.get("/api/v1/plays?uuid=%s" % parent._parent._play._uuid)
+            playbook_id = play["results"][0]["playbook"]
+
+        result["playbook"] = self.client.get("/api/v1/playbooks/%s" % playbook_id)
+        result["changed"] = False
+        result["msg"] = "Queried playbook %s from ARA" % playbook_id
+
+        return result

--- a/plugins/action/ara_record.py
+++ b/plugins/action/ara_record.py
@@ -1,0 +1,218 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.playbook.play import Play
+from ansible.plugins.action import ActionBase
+
+from ansible_collections.recordsansible.ara.plugins.module_utils import _utils as client_utils
+
+DOCUMENTATION = """
+---
+module: ara_record
+short_description: Ansible module to record persistent data with ARA.
+version_added: "2.0"
+author: "David Moreau-Simard <dmsimard@redhat.com>"
+description:
+    - Ansible module to record persistent data with ARA.
+options:
+    playbook_id:
+        description:
+            - id of the playbook to write the key to
+            - if not set, the module will use the ongoing playbook's id
+        required: false
+    key:
+        description:
+            - Name of the key to write data to
+        required: true
+    value:
+        description:
+            - Value of the key written to
+        required: true
+    type:
+        description:
+            - Type of the key
+        choices: [text, url, json, list, dict]
+        default: text
+
+requirements:
+    - "python >= 3.5"
+    - "ara >= 1.0.0"
+"""
+
+EXAMPLES = """
+- name: Associate specific data to a key for a playbook
+  ara_record:
+    key: "foo"
+    value: "bar"
+
+- name: Associate data to a playbook that previously ran
+  ara_record:
+    playbook_id: 21
+    key: logs
+    value: "{{ lookup('file', '/var/log/ansible.log') }}"
+    type: text
+
+- name: Retrieve the git version of the development repository
+  shell: cd dev && git rev-parse HEAD
+  register: git_version
+  delegate_to: localhost
+
+- name: Record and register the git version of the playbooks
+  ara_record:
+    key: "git_version"
+    value: "{{ git_version.stdout }}"
+  register: version
+
+- name: Print recorded data
+  debug:
+    msg: "{{ version.playbook_id }} - {{ version.key }}: {{ version.value }}
+
+# Write data with a type (otherwise defaults to "text")
+# This changes the behavior on how the value is presented in the web interface
+- name: Record different formats of things
+  ara_record:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+    type: "{{ item.type }}"
+  with_items:
+    - { key: "log", value: "error", type: "text" }
+    - { key: "website", value: "http://domain.tld", type: "url" }
+    - { key: "data", value: "{ 'key': 'value' }", type: "json" }
+    - { key: "somelist", value: ['one', 'two'], type: "list" }
+    - { key: "somedict", value: {'key': 'value' }, type: "dict" }
+"""
+
+
+RETURN = """
+playbook:
+    description: ID of the playbook the data was recorded in
+    returned: on success
+    type: int
+    sample: 1
+key:
+    description: Key where the record is saved
+    returned: on success
+    type: str
+    sample: log_url
+value:
+    description: Value of the key
+    returned: on success
+    type: complex
+    sample: http://logurl
+type:
+    description: Type of the key
+    returned: on success
+    type: string
+    sample: url
+created:
+    description: Date the record was created (ISO-8601)
+    returned: on success
+    type: str
+    sample: 2018-11-15T17:27:41.597234Z
+updated:
+    description: Date the record was updated (ISO-8601)
+    returned: on success
+    type: str
+    sample: 2018-11-15T17:27:41.597265Z
+"""
+
+
+class ActionModule(ActionBase):
+    """ Record persistent data as key/value pairs in ARA """
+
+    TRANSFERS_FILES = False
+    VALID_ARGS = frozenset(("playbook_id", "key", "value", "type"))
+    VALID_TYPES = ["text", "url", "json", "list", "dict"]
+
+    def __init__(self, *args, **kwargs):
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self.client = client_utils.active_client()
+
+    def create_or_update_key(self, playbook, key, value, type):
+        changed = False
+        record = self.client.get("/api/v1/records?playbook=%s&key=%s" % (playbook, key))
+        if record["count"] == 0:
+            # Create the record if it doesn't exist
+            record = self.client.post("/api/v1/records", playbook=playbook, key=key, value=value, type=type)
+            changed = True
+        else:
+            # Otherwise update it if the data is different (idempotency)
+            old = self.client.get("/api/v1/records/%s" % record["results"][0]["id"])
+            if old["value"] != value or old["type"] != type:
+                record = self.client.patch("/api/v1/records/%s" % old["id"], key=key, value=value, type=type)
+                changed = True
+            else:
+                record = old
+        return record, changed
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        for arg in self._task.args:
+            if arg not in self.VALID_ARGS:
+                result = {"failed": True, "msg": "{0} is not a valid option.".format(arg)}
+                return result
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        playbook_id = self._task.args.get("playbook_id", None)
+        key = self._task.args.get("key", None)
+        value = self._task.args.get("value", None)
+        type = self._task.args.get("type", "text")
+
+        required = ["key", "value"]
+        for parameter in required:
+            if not self._task.args.get(parameter):
+                result["failed"] = True
+                result["msg"] = "Parameter '{0}' is required".format(parameter)
+                return result
+
+        if type not in self.VALID_TYPES:
+            result["failed"] = True
+            msg = "Type '{0}' is not supported, choose one of: {1}".format(type, ", ".join(self.VALID_TYPES))
+            result["msg"] = msg
+            return result
+
+        if playbook_id is None:
+            # Retrieve the playbook id by working our way up from the task to find
+            # the play uuid. Once we have the play uuid, we can find the playbook.
+            parent = self._task
+            while not isinstance(parent._parent._play, Play):
+                parent = parent._parent
+
+            play = self.client.get("/api/v1/plays?uuid=%s" % parent._parent._play._uuid)
+            playbook_id = play["results"][0]["playbook"]
+
+        try:
+            data, changed = self.create_or_update_key(playbook_id, key, value, type)
+            result["changed"] = changed
+            result["key"] = data["key"]
+            result["value"] = data["value"]
+            result["type"] = data["type"]
+            result["playbook_id"] = data["playbook"]
+            result["created"] = data["created"]
+            result["updated"] = data["updated"]
+            if result["changed"]:
+                result["msg"] = "Record created or updated in ARA"
+            else:
+                result["msg"] = "Record unchanged in ARA"
+        except Exception as e:
+            result["changed"] = False
+            result["failed"] = True
+            result["msg"] = "Record failed to be created or updated in ARA: {0}".format(str(e))
+        return result

--- a/plugins/callback/ara_default.py
+++ b/plugins/callback/ara_default.py
@@ -1,0 +1,559 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+
+import datetime
+import json
+import logging
+import os
+import socket
+from concurrent.futures import ThreadPoolExecutor
+
+from ansible import __version__ as ansible_version
+from ansible.parsing.ajson import AnsibleJSONEncoder
+from ansible.plugins.callback import CallbackBase
+from ansible.vars.clean import module_response_deepcopy, strip_internal_keys
+
+from ansible_collections.recordsansible.ara.plugins.module_utils import _utils as client_utils
+
+# Ansible CLI options are now in ansible.context in >= 2.8
+# https://github.com/ansible/ansible/commit/afdbb0d9d5bebb91f632f0d4a1364de5393ba17a
+try:
+    from ansible import context
+
+    cli_options = {key: value for key, value in context.CLIARGS.items()}
+except ImportError:
+    # < 2.8 doesn't have ansible.context
+    try:
+        from __main__ import cli
+
+        cli_options = cli.options.__dict__
+    except ImportError:
+        # using API without CLI
+        cli_options = {}
+
+
+DOCUMENTATION = """
+callback: ara
+callback_type: notification
+requirements:
+  - ara
+short_description: Sends playbook execution data to the ARA API internally or over HTTP
+description:
+  - Sends playbook execution data to the ARA API internally or over HTTP
+options:
+  api_client:
+    description: The client to use for communicating with the API
+    default: offline
+    env:
+      - name: ARA_API_CLIENT
+    ini:
+      - section: ara
+        key: api_client
+    choices: ['offline', 'http']
+  api_server:
+    description: When using the HTTP client, the base URL to the ARA API server
+    default: http://127.0.0.1:8000
+    env:
+      - name: ARA_API_SERVER
+    ini:
+      - section: ara
+        key: api_server
+  api_username:
+    description: If authentication is required, the username to authenticate with
+    default: null
+    env:
+      - name: ARA_API_USERNAME
+    ini:
+      - section: ara
+        key: api_username
+  api_password:
+    description: If authentication is required, the password to authenticate with
+    default: null
+    env:
+      - name: ARA_API_PASSWORD
+    ini:
+      - section: ara
+        key: api_password
+  api_insecure:
+    description: Can be enabled to ignore SSL certification of the API server
+    type: bool
+    default: false
+    env:
+      - name: ARA_API_INSECURE
+    ini:
+      - section: ara
+        key: api_insecure
+  api_timeout:
+    description: Timeout, in seconds, before giving up on HTTP requests
+    type: integer
+    default: 30
+    env:
+      - name: ARA_API_TIMEOUT
+    ini:
+      - section: ara
+        key: api_timeout
+  argument_labels:
+    description: |
+        A list of CLI arguments that, if set, will be automatically applied to playbooks as labels.
+        Note that CLI arguments are not always named the same as how they are represented by Ansible.
+        For example, --limit is "subset", --user is "remote_user" but --check is "check".
+    type: list
+    default:
+      - remote_user
+      - check
+      - tags
+      - skip_tags
+      - subset
+    env:
+      - name: ARA_ARGUMENT_LABELS
+    ini:
+      - section: ara
+        key: argument_labels
+  default_labels:
+    description: A list of default labels that will be applied to playbooks
+    type: list
+    default: []
+    env:
+      - name: ARA_DEFAULT_LABELS
+    ini:
+      - section: ara
+        key: default_labels
+  ignored_facts:
+    description: List of host facts that will not be saved by ARA
+    type: list
+    default: ["ansible_env"]
+    env:
+      - name: ARA_IGNORED_FACTS
+    ini:
+      - section: ara
+        key: ignored_facts
+  ignored_arguments:
+    description: List of Ansible arguments that will not be saved by ARA
+    type: list
+    default: ["extra_vars"]
+    env:
+      - name: ARA_IGNORED_ARGUMENTS
+    ini:
+      - section: ara
+        key: ignored_arguments
+  ignored_files:
+    description: List of patterns that will not be saved by ARA
+    type: list
+    default: []
+    env:
+      - name: ARA_IGNORED_FILES
+    ini:
+      - section: ara
+        key: ignored_files
+  callback_threads:
+    description:
+      - The number of threads to use in API client thread pools
+      - When set to 0, no threading will be used (default) which is appropriate for usage with sqlite
+      - Using threads is recommended when the server is using MySQL or PostgreSQL
+    type: integer
+    default: 0
+    env:
+      - name: ARA_CALLBACK_THREADS
+    ini:
+      - section: ara
+        key: callback_threads
+"""
+
+
+class CallbackModule(CallbackBase):
+    """
+    Saves data from an Ansible run into a database
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = "awesome"
+    CALLBACK_NAME = "ara_default"
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.log = logging.getLogger("ara.plugins.callback.default")
+        # These are configured in self.set_options
+        self.client = None
+        self.callback_threads = None
+
+        self.ignored_facts = []
+        self.ignored_arguments = []
+        self.ignored_files = []
+
+        self.result = None
+        self.result_started = {}
+        self.result_ended = {}
+        self.task = None
+        self.play = None
+        self.playbook = None
+        self.stats = None
+        self.file_cache = {}
+        self.host_cache = {}
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        self.argument_labels = self.get_option("argument_labels")
+        self.default_labels = self.get_option("default_labels")
+        self.ignored_facts = self.get_option("ignored_facts")
+        self.ignored_arguments = self.get_option("ignored_arguments")
+        self.ignored_files = self.get_option("ignored_files")
+
+        client = self.get_option("api_client")
+        endpoint = self.get_option("api_server")
+        timeout = self.get_option("api_timeout")
+        username = self.get_option("api_username")
+        password = self.get_option("api_password")
+        insecure = self.get_option("api_insecure")
+        self.client = client_utils.get_client(
+            client=client,
+            endpoint=endpoint,
+            timeout=timeout,
+            username=username,
+            password=password,
+            verify=False if insecure else True,
+        )
+
+        # TODO: Consider un-hardcoding this and plumbing pool_maxsize to requests.adapters.HTTPAdapter.
+        #       In the meantime default to 4 so we don't go above requests.adapters.DEFAULT_POOLSIZE.
+        #       Otherwise we can hit "urllib3.connectionpool: Connection pool is full"
+        self.callback_threads = self.get_option("callback_threads")
+        if self.callback_threads > 4:
+            self.callback_threads = 4
+
+    def _submit_thread(self, threadpool, func, *args, **kwargs):
+        # Manages whether or not the function should be threaded to keep things DRY
+        if self.callback_threads:
+            # Pick from one of two thread pools (global or task)
+            threads = getattr(self, threadpool + "_threads")
+            threads.submit(func, *args, **kwargs)
+        else:
+            func(*args, **kwargs)
+
+    def v2_playbook_on_start(self, playbook):
+        self.log.debug("v2_playbook_on_start")
+
+        if self.callback_threads:
+            self.global_threads = ThreadPoolExecutor(max_workers=self.callback_threads)
+            self.log.debug("Global thread pool initialized with %s thread(s)" % self.callback_threads)
+
+        content = None
+
+        if playbook._file_name == "__adhoc_playbook__":
+            content = cli_options["module_name"]
+            if cli_options["module_args"]:
+                content = "{0}: {1}".format(content, cli_options["module_args"])
+            path = "Ad-Hoc: {0}".format(content)
+        else:
+            path = os.path.abspath(playbook._file_name)
+
+        # Potentially sanitize some user-specified keys
+        for argument in self.ignored_arguments:
+            if argument in cli_options:
+                self.log.debug("Ignoring argument: %s" % argument)
+                cli_options[argument] = "Not saved by ARA as configured by 'ignored_arguments'"
+
+        # Retrieve and format CLI options for argument labels
+        argument_labels = []
+        for label in self.argument_labels:
+            if label in cli_options:
+                # Some arguments are lists or tuples
+                if isinstance(cli_options[label], tuple) or isinstance(cli_options[label], list):
+                    # Only label these if they're not empty
+                    if cli_options[label]:
+                        argument_labels.append("%s:%s" % (label, ",".join(cli_options[label])))
+                # Some arguments are booleans
+                elif isinstance(cli_options[label], bool):
+                    argument_labels.append("%s:%s" % (label, cli_options[label]))
+                # The rest can be printed as-is if there is something set
+                elif cli_options[label]:
+                    argument_labels.append("%s:%s" % (label, cli_options[label]))
+        self.argument_labels = argument_labels
+
+        # Create the playbook
+        self.playbook = self.client.post(
+            "/api/v1/playbooks",
+            ansible_version=ansible_version,
+            arguments=cli_options,
+            status="running",
+            path=path,
+            controller=socket.getfqdn(),
+            started=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+
+        # Record the playbook file
+        self._submit_thread("global", self._get_or_create_file, path, content)
+
+        return self.playbook
+
+    def v2_playbook_on_play_start(self, play):
+        self.log.debug("v2_playbook_on_play_start")
+        self._end_task()
+        self._end_play()
+
+        # Load variables to verify if there is anything relevant for ara
+        play_vars = play._variable_manager.get_vars(play=play)["vars"]
+        if "ara_playbook_name" in play_vars:
+            self._submit_thread("global", self._set_playbook_name, play_vars["ara_playbook_name"])
+
+        labels = self.default_labels + self.argument_labels
+        if "ara_playbook_labels" in play_vars:
+            # ara_playbook_labels can be supplied as a list inside a playbook
+            # but it might also be specified as a comma separated string when
+            # using extra-vars
+            if isinstance(play_vars["ara_playbook_labels"], list):
+                labels.extend(play_vars["ara_playbook_labels"])
+            elif isinstance(play_vars["ara_playbook_labels"], str):
+                labels.extend(play_vars["ara_playbook_labels"].split(","))
+            else:
+                raise TypeError("ara_playbook_labels must be a list or a comma-separated string")
+        if labels:
+            self._submit_thread("global", self._set_playbook_labels, labels)
+
+        # Record all the files involved in the play
+        for path in play._loader._FILE_CACHE.keys():
+            self._submit_thread("global", self._get_or_create_file, path)
+
+        # Create the play
+        self.play = self.client.post(
+            "/api/v1/plays",
+            name=play.name,
+            status="running",
+            uuid=play._uuid,
+            playbook=self.playbook["id"],
+            started=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+
+        return self.play
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.log.debug("v2_playbook_on_handler_task_start")
+        # TODO: Why doesn't `v2_playbook_on_handler_task_start` have is_conditional ?
+        self.v2_playbook_on_task_start(task, False, handler=True)
+
+    def v2_playbook_on_task_start(self, task, is_conditional, handler=False):
+        self.log.debug("v2_playbook_on_task_start")
+        self._end_task()
+
+        if self.callback_threads:
+            self.task_threads = ThreadPoolExecutor(max_workers=self.callback_threads)
+            self.log.debug("Task thread pool initialized with %s thread(s)" % self.callback_threads)
+
+        pathspec = task.get_path()
+        if pathspec:
+            path, lineno = pathspec.split(":", 1)
+            lineno = int(lineno)
+        else:
+            # Task doesn't have a path, default to "something"
+            path = self.playbook["path"]
+            lineno = 1
+
+        # Get task file
+        task_file = self._get_or_create_file(path)
+
+        self.task = self.client.post(
+            "/api/v1/tasks",
+            name=task.get_name(),
+            status="running",
+            action=task.action,
+            play=self.play["id"],
+            playbook=self.playbook["id"],
+            file=task_file["id"],
+            tags=task.tags,
+            lineno=lineno,
+            handler=handler,
+            started=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+
+        return self.task
+
+    def v2_runner_on_start(self, host, task):
+        # v2_runner_on_start was added in 2.8 so this doesn't get run for Ansible 2.7 and below.
+        self.result_started[host.get_name()] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        self._submit_thread("task", self._load_result, result, "ok", **kwargs)
+
+    def v2_runner_on_unreachable(self, result, **kwargs):
+        self._submit_thread("task", self._load_result, result, "unreachable", **kwargs)
+
+    def v2_runner_on_failed(self, result, **kwargs):
+        self._submit_thread("task", self._load_result, result, "failed", **kwargs)
+
+    def v2_runner_on_skipped(self, result, **kwargs):
+        self._submit_thread("task", self._load_result, result, "skipped", **kwargs)
+
+    def v2_playbook_on_stats(self, stats):
+        self.log.debug("v2_playbook_on_stats")
+        self._end_task()
+        self._end_play()
+        self._load_stats(stats)
+        self._end_playbook(stats)
+
+    def _end_task(self):
+        if self.task is not None:
+            self._submit_thread(
+                "task",
+                self.client.patch,
+                "/api/v1/tasks/%s" % self.task["id"],
+                status="completed",
+                ended=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            )
+            if self.callback_threads:
+                # Flush threads before moving on to next task to make sure all results are saved
+                self.log.debug("waiting for task threads...")
+                self.task_threads.shutdown(wait=True)
+                self.task_threads = None
+            self.task = None
+
+    def _end_play(self):
+        if self.play is not None:
+            self._submit_thread(
+                "global",
+                self.client.patch,
+                "/api/v1/plays/%s" % self.play["id"],
+                status="completed",
+                ended=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            )
+            self.play = None
+
+    def _end_playbook(self, stats):
+        status = "unknown"
+        if len(stats.failures) >= 1 or len(stats.dark) >= 1:
+            status = "failed"
+        else:
+            status = "completed"
+
+        self._submit_thread(
+            "global",
+            self.client.patch,
+            "/api/v1/playbooks/%s" % self.playbook["id"],
+            status=status,
+            ended=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+
+        if self.callback_threads:
+            self.log.debug("waiting for global threads...")
+            self.global_threads.shutdown(wait=True)
+
+    def _set_playbook_name(self, name):
+        if self.playbook["name"] != name:
+            self.playbook = self.client.patch("/api/v1/playbooks/%s" % self.playbook["id"], name=name)
+
+    def _set_playbook_labels(self, labels):
+        # Only update labels if our cache doesn't match
+        current_labels = [label["name"] for label in self.playbook["labels"]]
+        if sorted(current_labels) != sorted(labels):
+            self.log.debug("Updating playbook labels to match: %s" % ",".join(labels))
+            self.playbook = self.client.patch("/api/v1/playbooks/%s" % self.playbook["id"], labels=labels)
+
+    def _get_or_create_file(self, path, content=None):
+        if path not in self.file_cache:
+            self.log.debug("File not in cache, getting or creating: %s" % path)
+            for ignored_file_pattern in self.ignored_files:
+                if ignored_file_pattern in path:
+                    self.log.debug("Ignoring file {1}, matched pattern: {0}".format(ignored_file_pattern, path))
+                    content = "Not saved by ARA as configured by 'ignored_files'"
+            if content is None:
+                try:
+                    with open(path, "r") as fd:
+                        content = fd.read()
+                except IOError as e:
+                    self.log.error("Unable to open {0} for reading: {1}".format(path, str(e)))
+                    content = """ARA was not able to read this file successfully.
+                            Refer to the logs for more information"""
+
+            self.file_cache[path] = self.client.post(
+                "/api/v1/files", playbook=self.playbook["id"], path=path, content=content
+            )
+
+        return self.file_cache[path]
+
+    def _get_or_create_host(self, host):
+        # Note: The get_or_create is handled through the serializer of the API server.
+        if host not in self.host_cache:
+            self.log.debug("Host not in cache, getting or creating: %s" % host)
+            self.host_cache[host] = self.client.post("/api/v1/hosts", name=host, playbook=self.playbook["id"])
+        return self.host_cache[host]
+
+    def _load_result(self, result, status, **kwargs):
+        """
+        This method is called when an individual task instance on a single
+        host completes. It is responsible for logging a single result to the
+        database.
+        """
+        hostname = result._host.get_name()
+        self.result_ended[hostname] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        # Retrieve the host so we can associate the result to the host id
+        host = self._get_or_create_host(hostname)
+
+        results = strip_internal_keys(module_response_deepcopy(result._result))
+
+        # Round-trip through JSON to sort keys and convert Ansible types
+        # to standard types
+        try:
+            jsonified = json.dumps(results, cls=AnsibleJSONEncoder, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            # Python 3 can't sort non-homogenous keys.
+            # https://bugs.python.org/issue25457
+            jsonified = json.dumps(results, cls=AnsibleJSONEncoder, ensure_ascii=False, sort_keys=False)
+        results = json.loads(jsonified)
+
+        # Sanitize facts
+        if "ansible_facts" in results:
+            for fact in self.ignored_facts:
+                if fact in results["ansible_facts"]:
+                    self.log.debug("Ignoring fact: %s" % fact)
+                    results["ansible_facts"][fact] = "Not saved by ARA as configured by 'ignored_facts'"
+
+        self.result = self.client.post(
+            "/api/v1/results",
+            playbook=self.playbook["id"],
+            task=self.task["id"],
+            host=host["id"],
+            play=self.task["play"],
+            content=results,
+            status=status,
+            started=self.result_started[hostname] if hostname in self.result_started else self.task["started"],
+            ended=self.result_ended[hostname],
+            changed=result._result.get("changed", False),
+            # Note: ignore_errors might be None instead of a boolean
+            ignore_errors=kwargs.get("ignore_errors", False) or False,
+        )
+
+        if self.task["action"] in ["setup", "gather_facts"] and "ansible_facts" in results:
+            self.client.patch("/api/v1/hosts/%s" % host["id"], facts=results["ansible_facts"])
+
+    def _load_stats(self, stats):
+        hosts = sorted(stats.processed.keys())
+        for hostname in hosts:
+            host = self._get_or_create_host(hostname)
+            host_stats = stats.summarize(hostname)
+
+            self._submit_thread(
+                "global",
+                self.client.patch,
+                "/api/v1/hosts/%s" % host["id"],
+                changed=host_stats["changed"],
+                unreachable=host_stats["unreachable"],
+                failed=host_stats["failures"],
+                ok=host_stats["ok"],
+                skipped=host_stats["skipped"],
+            )

--- a/plugins/lookup/ara_api.py
+++ b/plugins/lookup/ara_api.py
@@ -1,0 +1,63 @@
+#  Copyright (c) 2019 Red Hat, Inc.
+#
+#  This file is part of ARA Records Ansible.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from __future__ import absolute_import, division, print_function
+
+from ansible.plugins.lookup import LookupBase
+
+from ansible_collections.recordsansible.ara.plugins.module_utils import _utils as client_utils
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: ara_api
+    author: David Moreau-Simard (@dmsimard)
+    version_added: "2.9"
+    short_description: Queries the ARA API for data
+    description:
+        - Queries the ARA API for data
+    options:
+        _terms:
+            description:
+                - The endpoint to query
+            type: list
+            elements: string
+            required: True
+"""
+
+EXAMPLES = """
+    - debug: msg="{{ lookup('ara_api','/api/v1/playbooks/1') }}"
+"""
+
+RETURN = """
+    _raw:
+        description: response from query
+"""
+
+
+class LookupModule(LookupBase):
+    def __init__(self, *args, **kwargs):
+        super(LookupModule, self).__init__(*args, **kwargs)
+        self.client = client_utils.active_client()
+
+    def run(self, terms, variables, **kwargs):
+        ret = []
+        for term in terms:
+            ret.append(self.client.get(term))
+
+        return ret

--- a/plugins/module_utils/_exceptions.py
+++ b/plugins/module_utils/_exceptions.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2019 Red Hat, Inc.
+#
+#  This file is part of ARA Records Ansible.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class MissingDjangoException(Exception):
+    def __init__(self):
+        exc = "The server dependencies must be installed to record data offline or run the API server."
+        super().__init__(exc)
+
+
+class MissingPsycopgException(Exception):
+    def __init__(self):
+        exc = "The psycopg2 python library must be installed in order to use the PostgreSQL database engine."
+        super().__init__(exc)
+
+
+class MissingMysqlclientException(Exception):
+    def __init__(self):
+        exc = "The mysqlclient python library must be installed in order to use the MySQL database engine."
+        super().__init__(exc)
+
+
+class MissingSettingsException(Exception):
+    def __init__(self):
+        exc = "The specified settings file does not exist or permissions are insufficient to read it."
+        super().__init__(exc)

--- a/plugins/module_utils/_http.py
+++ b/plugins/module_utils/_http.py
@@ -1,0 +1,121 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is an "offline" API client that does not require standing up
+# an API server and does not execute actual HTTP calls.
+
+import json
+import logging
+import weakref
+
+import pbr.version
+import requests
+
+from ansible_collections.recordsansible.ara.plugins.module_utils._utils import active_client
+
+CLIENT_VERSION = pbr.version.VersionInfo("ara").release_string()
+
+
+class HttpClient(object):
+    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, timeout=30, verify=True):
+        self.log = logging.getLogger(__name__)
+
+        self.endpoint = endpoint.rstrip("/")
+        self.auth = auth
+        self.timeout = int(timeout)
+        self.verify = verify
+        self.headers = {
+            "User-Agent": "ara-http-client_%s" % CLIENT_VERSION,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        self.http = requests.Session()
+        self.http.headers.update(self.headers)
+        if self.auth is not None:
+            self.http.auth = self.auth
+        self.http.verify = self.verify
+
+    def _request(self, method, url, **payload):
+        # Use requests.Session to do the query
+        # The actual endpoint is:
+        # <endpoint>              <url>
+        # http://127.0.0.1:8000 / api/v1/playbooks
+        return self.http.request(method, self.endpoint + url, timeout=self.timeout, **payload)
+
+    def get(self, url, **payload):
+        if payload:
+            return self._request("get", url, **payload)
+        else:
+            return self._request("get", url)
+
+    def patch(self, url, **payload):
+        return self._request("patch", url, data=json.dumps(payload))
+
+    def post(self, url, **payload):
+        return self._request("post", url, data=json.dumps(payload))
+
+    def put(self, url, **payload):
+        return self._request("put", url, data=json.dumps(payload))
+
+    def delete(self, url):
+        return self._request("delete", url)
+
+
+class AraHttpClient(object):
+    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, timeout=30, verify=True):
+        self.log = logging.getLogger(__name__)
+        self.endpoint = endpoint
+        self.auth = auth
+        self.timeout = int(timeout)
+        self.verify = verify
+        self.client = HttpClient(endpoint=self.endpoint, timeout=self.timeout, auth=self.auth, verify=self.verify)
+        active_client._instance = weakref.ref(self)
+
+    def _request(self, method, url, **kwargs):
+        func = getattr(self.client, method)
+        if method == "delete":
+            response = func(url)
+        else:
+            response = func(url, **kwargs)
+
+        if response.status_code >= 500:
+            self.log.error("Failed to {method} on {url}: {content}".format(method=method, url=url, content=kwargs))
+
+        self.log.debug("HTTP {status}: {method} on {url}".format(status=response.status_code, method=method, url=url))
+
+        if response.status_code not in [200, 201, 204]:
+            self.log.error("Failed to {method} on {url}: {content}".format(method=method, url=url, content=kwargs))
+
+        if response.status_code == 204:
+            return response
+
+        return response.json()
+
+    def get(self, endpoint, **kwargs):
+        return self._request("get", endpoint, params=kwargs)
+
+    def patch(self, endpoint, **kwargs):
+        return self._request("patch", endpoint, **kwargs)
+
+    def post(self, endpoint, **kwargs):
+        return self._request("post", endpoint, **kwargs)
+
+    def put(self, endpoint, **kwargs):
+        return self._request("put", endpoint, **kwargs)
+
+    def delete(self, endpoint, **kwargs):
+        return self._request("delete", endpoint)

--- a/plugins/module_utils/_offline.py
+++ b/plugins/module_utils/_offline.py
@@ -1,0 +1,96 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is an "offline" API client that does not require standing up
+# an API server and does not execute actual HTTP calls.
+
+import logging
+import os
+import threading
+
+from ansible_collections.recordsansible.ara.plugins.module_utils._http import AraHttpClient
+from ansible_collections.recordsansible.ara.plugins.module_utils._exceptions import MissingDjangoException
+
+try:
+    from django.core.handlers.wsgi import WSGIHandler
+    from django.core.servers.basehttp import ThreadedWSGIServer, WSGIRequestHandler
+except ImportError as e:
+    raise MissingDjangoException from e
+
+
+class AraOfflineClient(AraHttpClient):
+    def __init__(self, auth=None, run_sql_migrations=True):
+        self.log = logging.getLogger(__name__)
+
+        from django import setup as django_setup
+        from django.core.management import execute_from_command_line
+
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ara.server.settings")
+
+        if run_sql_migrations:
+            # Automatically create the database and run migrations (is there a better way?)
+            execute_from_command_line(["django", "migrate"])
+
+        # Set up the things Django needs
+        django_setup()
+
+        self._start_server()
+        super().__init__(endpoint="http://localhost:%d" % self.server_thread.port, auth=auth)
+
+    def _start_server(self):
+        self.server_thread = ServerThread("localhost")
+        self.server_thread.start()
+
+        # Wait for the live server to be ready
+        self.server_thread.is_ready.wait()
+        if self.server_thread.error:
+            raise self.server_thread.error
+
+
+class ServerThread(threading.Thread):
+    def __init__(self, host, port=0):
+        self.host = host
+        self.port = port
+        self.is_ready = threading.Event()
+        self.error = None
+        super().__init__(daemon=True)
+
+    def run(self):
+        """
+        Set up the live server and databases, and then loop over handling
+        HTTP requests.
+        """
+        try:
+            # Create the handler for serving static and media files
+            self.httpd = self._create_server()
+            # If binding to port zero, assign the port allocated by the OS.
+            if self.port == 0:
+                self.port = self.httpd.server_address[1]
+            self.httpd.set_app(WSGIHandler())
+            self.is_ready.set()
+            self.httpd.serve_forever()
+        except Exception as e:
+            self.error = e
+            self.is_ready.set()
+
+    def _create_server(self):
+        return ThreadedWSGIServer((self.host, self.port), QuietWSGIRequestHandler, allow_reuse_address=False)
+
+
+class QuietWSGIRequestHandler(WSGIRequestHandler):
+    def log_message(*args):
+        pass

--- a/plugins/module_utils/_utils.py
+++ b/plugins/module_utils/_utils.py
@@ -1,0 +1,53 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  This file is part of ARA Records Ansible.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+from requests.auth import HTTPBasicAuth
+
+
+def get_client(
+    client="offline",
+    endpoint="http://127.0.0.1:8000",
+    timeout=30,
+    username=None,
+    password=None,
+    verify=True,
+    run_sql_migrations=True,
+):
+    """
+    Returns a specified client configuration or one with sane defaults.
+    """
+    auth = None
+    if username is not None and password is not None:
+        auth = HTTPBasicAuth(username, password)
+
+    if client == "offline":
+        from ansible_collections.recordsansible.ara.plugins.module_utils._offline import AraOfflineClient
+
+        return AraOfflineClient(auth=auth, run_sql_migrations=run_sql_migrations)
+    elif client == "http":
+        from ansible_collections.recordsansible.ara.plugins.module_utils._http import AraHttpClient
+
+        return AraHttpClient(endpoint=endpoint, timeout=timeout, auth=auth, verify=verify)
+    else:
+        raise ValueError("Unsupported API client: %s (use 'http' or 'offline')" % client)
+
+
+def active_client():
+    return active_client._instance()
+
+
+active_client._instance = None


### PR DESCRIPTION
:dragon_face: ! HERE BE DRAGONS ! :dragon_face: 

So this is a highly experimental change, I mainly made the PR for proof of concept purposes.

The idea behind is is the same as what the Foreman guys did last october with https://github.com/theforeman/foreman-ansible-modules/commit/0eb76b8b5ab1bda9d82e5209b9bd2832759ae0e1

This change allows systems without any ARA package installed from Pypi to still talk to ARA API's:

```
root@ansible-dev (vendor_ara_client):ara$ pip3 list | grep ara
paramiko                 2.7.1
python-saharaclient      2.0.0
root@ansible-dev (vendor_ara_client):ara$ pip3 list --user | grep ara
root@ansible-dev (vendor_ara_client):ara$ 
```

Required ```ansible.cfg``` snippet
```
callback_whitelist = community.general.yaml, recordsansible.ara.ara_default
```

![image](https://user-images.githubusercontent.com/12935477/115129751-2d3b7600-9fe9-11eb-9c62-ef768949b35e.png)

So the question is, do we want to go this route?