### PR TITLE
Update dependency file for CentOS/RHEL 8

### DIFF
--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -227,5 +227,3 @@ ara_api_cleanup_crons:
   - name: ara_api prune old reports
     arguments: 'playbook prune --server http://localhost:8000 --client http --confirm --days 30'
     special_time: 'daily'
-
-#.

--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -227,3 +227,5 @@ ara_api_cleanup_crons:
   - name: ara_api prune old reports
     arguments: 'playbook prune --server http://localhost:8000 --client http --confirm --days 30'
     special_time: 'daily'
+
+#.

--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -59,6 +59,10 @@ ara_api_source_checkout: "{{ ara_api_root_dir }}/git/ara"
 # When using "latest" as the pypi version, the latest release will be used
 ara_api_version: master
 
+# RHEL/CentOS only: Python version used, no dots.
+# This will install the desired python version from AppStreams
+ara_python_version: 38 # Python 3.8
+
 # The frontend/web server for serving the ARA API
 # It is recommended to specify a web server when deploying a production environment.
 # - null [default]: No frontend server will be set up.

--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -61,7 +61,7 @@ ara_api_version: master
 
 # RHEL/CentOS only: Python version used, no dots.
 # This will install the desired python version from AppStreams
-ara_python_version: 38 # Python 3.8
+ara_python_version: 36 # Python 3.6
 
 # The frontend/web server for serving the ARA API
 # It is recommended to specify a web server when deploying a production environment.

--- a/roles/ara_api/tasks/main.yaml
+++ b/roles/ara_api/tasks/main.yaml
@@ -19,6 +19,7 @@
 - name: Include OS family/distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_facts['distribution'] }}{{ ansible_facts['distribution_major_version'] }}.yaml"
     - "{{ ansible_facts['distribution'] }}.yaml"
     - "{{ ansible_facts['os_family'] }}.yaml"
 

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -21,7 +21,7 @@
 # but we want to use the non-system one. Install it if it's missing.
 - name: Ensure python3 is installed for EL8
   package:
-    name: python3
+    name: python{{ ara_python_version }}
     state: present
   become: yes
   when:

--- a/roles/ara_api/vars/CentOS8.yaml
+++ b/roles/ara_api/vars/CentOS8.yaml
@@ -19,9 +19,6 @@
 # ARA has not been packaged for CentOS or RHEL yet
 ara_distribution_packages: []
 
-# Python version used, no dots, must be at least 3.6
-ara_python_version: 38 # Python 3.8
-
 ara_api_required_packages:
   - git
   - python{{ ara_python_version }}

--- a/roles/ara_api/vars/CentOS8.yaml
+++ b/roles/ara_api/vars/CentOS8.yaml
@@ -1,0 +1,43 @@
+---
+#  Copyright (c) 2019 Red Hat, Inc.
+#
+#  This file is part of ARA Records Ansible.
+#
+#  ARA Records Ansible is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA Records Ansible is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA Records Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+# ARA has not been packaged for CentOS or RHEL yet
+ara_distribution_packages: []
+
+# Python version used, no dots, must be at least 3.6
+ara_python_version: 38 # Python 3.8
+
+ara_api_required_packages:
+  - git
+  - python{{ ara_python_version }}
+  - policycoreutils-python-utils
+  # cronie provides crontab
+  - cronie
+
+ara_api_postgresql_packages:
+  - postgresql
+  - postgresql-devel
+  - python{{ ara_python_version }}-devel
+  - gcc
+
+ara_api_mysql_packages:
+  - mariadb
+  - mariadb-connector-c-devel
+  - redhat-rpm-config
+  - python{{ ara_python_version }}-devel
+  - gcc

--- a/roles/ara_api/vars/RedHat8.yaml
+++ b/roles/ara_api/vars/RedHat8.yaml
@@ -1,0 +1,1 @@
+CentOS8.yaml

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -28,6 +28,11 @@
         _install_ansible_state: latest
       when: ara_tests_ansible_version == "latest"
 
+    - name: Install dependencies
+      pip:
+        name: setuptools_rust
+        state: present
+
     - name: Install Ansible alongside ARA
       pip:
         name: "{{ ara_tests_ansible_name }}"

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -28,11 +28,6 @@
         _install_ansible_state: latest
       when: ara_tests_ansible_version == "latest"
 
-    - name: Install dependencies
-      pip:
-        name: setuptools_rust
-        state: present
-
     - name: Install Ansible alongside ARA
       pip:
         name: "{{ ara_tests_ansible_name }}"


### PR DESCRIPTION
Centos8 no longer has the python3 package, instead they offer multiple versions of python3 via AppStreams. 

This commit changes the role to support that.

It adds a new distribution variable which sets the python version.