### PR TITLE
postgresql: pin psycopg2<2.9

### DIFF
--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -37,7 +37,9 @@
 # https://docs.djangoproject.com/en/2.2/ref/databases/#postgresql-notes
 - name: Ensure psycopg2 is installed
   pip:
-    name: psycopg2
+    # Pin psycopg2 until we upgrade to django 3.2 LTS
+    # https://github.com/ansible-community/ara/issues/320
+    name: psycopg2<2.9
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv

--- a/tests/zuul_post_logs.yaml
+++ b/tests/zuul_post_logs.yaml
@@ -16,27 +16,35 @@
         state: directory
         recurse: yes
 
-    - name: Recover integration test data
-      command: cp -rp {{ ara_api_root_dir }}/server {{ ansible_user_dir }}/zuul-output/logs/server
-      ignore_errors: yes
+    - when: groups['all'] | length > 1
+      name: Prepare logs when running multi-node
+      block:
+        - name: Recover integration test data
+          command: cp -rp {{ ara_api_root_dir }}/server {{ ansible_user_dir }}/zuul-output/logs/{{ inventory_hostname }}
+          ignore_errors: yes
 
-    - name: Link the static report to the Zuul build with multiple nodes
-      zuul_return:
-        data:
-          zuul:
-            artifacts:
-               - name: "Integration test static report for {{ inventory_hostname }}"
-                 url: "{{ inventory_hostname }}/server/static/index.html"
-      when: groups['all'] | length > 1
+        - name: Link the static report to the Zuul build
+          zuul_return:
+            data:
+              zuul:
+                artifacts:
+                  - name: "Integration test static report for {{ inventory_hostname }}"
+                    url: "{{ inventory_hostname }}/static/index.html"
 
-    - name: Link the static report to the Zuul build with a single node
-      zuul_return:
-        data:
-          zuul:
-            artifacts:
-               - name: Integration test static report
-                 url: "server/static/index.html"
-      when: groups['all'] | length == 1
+    - when: groups['all'] | length == 1
+      name: Prepare logs without multi-node
+      block:
+        - name: Recover integration test data
+          command: cp -rp {{ ara_api_root_dir }}/server {{ ansible_user_dir }}/zuul-output/logs/server
+          ignore_errors: yes
+
+        - name: Link the static report to the Zuul build
+          zuul_return:
+            data:
+              zuul:
+                artifacts:
+                  - name: Integration test static report
+                    url: "server/static/index.html"
 
 # Temporarily disable this to prevent "Executing local code is prohibited"
 # https://review.opendev.org/#/c/742229/


### PR DESCRIPTION
There is an incompatibility between psycopg2>=2.9 and django 2.2 LTS.
We need to pin until we upgrade to django 3.2 LTS.

See https://github.com/ansible-community/ara/issues/320 for details.