### PR TITLE
ara_api: use python36 package for el8

### DIFF
--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -16,31 +16,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with ARA Records Ansible. If not, see <http://www.gnu.org/licenses/>.
 
-# EL8 doesn't install a python3 interpreter by default.
-# System packages rely on /usr/libexec/platform-python and Ansible will use it
-# but we want to use the non-system one. Install it if it's missing.
-- name: Ensure python3 is installed for EL8
-  package:
-    name: python3
-    state: present
-  become: yes
-  when:
-    - ansible_facts['distribution'] | lower in ["redhat", "centos"]
-    - ansible_facts['distribution_major_version'] == "8"
-
-# The ansible_python_version fact might end up retrieving the version of
-# python2 so we need to explicitely get the version of python 3 available.
-- name: Validate availability of Python 3.5
-  command: /usr/bin/python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'
-  changed_when: false
-  failed_when: false
-  register: python_version
-
-- name: Fail pre-emptively if running Python <3.5
-  fail:
-    msg: "Python >=3.5 is required to run ARA"
-  when: python_version.stdout is version('3.5', '<') or python_version.rc != 0
-
 - name: Get list of installed packages
   package_facts:
     manager: "auto"
@@ -62,6 +37,19 @@
     - name: Fail due to missing packages
       fail:
         msg: "Failed to elevate privileges and install missing required packages. Install the following packages before running this role again: {{ ara_missing_packages | join(' ') }}"
+
+# The ansible_python_version fact might end up retrieving the version of
+# python2 so we need to explicitely get the version of python 3 available.
+- name: Validate availability of Python 3.5
+  command: /usr/bin/python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'
+  changed_when: false
+  failed_when: false
+  register: python_version
+
+- name: Fail pre-emptively if running Python <3.5
+  fail:
+    msg: "Python >=3.5 is required to run ARA"
+  when: python_version.stdout is version('3.5', '<') or python_version.rc != 0
 
 # The following tasks dynamically enable escalated privileges only when the
 # directory to create is not located in the user's home directory.

--- a/roles/ara_api/vars/CentOS.yaml
+++ b/roles/ara_api/vars/CentOS.yaml
@@ -19,9 +19,12 @@
 # ARA has not been packaged for CentOS or RHEL yet
 ara_distribution_packages: []
 
+# EL8 doesn't install a python3 interpreter by default.
+# System packages rely on /usr/libexec/platform-python and Ansible will use it
+# but we want to use the non-system one. Install it if it's missing.
 ara_api_required_packages:
   - git
-  - python3
+  - python36
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -29,12 +32,12 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
-  - python3-devel
+  - python36-devel
   - gcc
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
-  - python3-devel
+  - python36-devel
   - gcc


### PR DESCRIPTION
Centos8 no longer has the python3 package, instead they offer
multiple versions of python3 via AppStreams.