### PR TITLE
Add support for managing authentication in ara_frontend_nginx

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -22,7 +22,9 @@
       - galaxy.yml
     vars:
       ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
-      ara_tests_ansible_name: "{{ ansible_user_dir }}/src/github.com/ansible/ansible"
+      # If installing from source with ansible/ansible in zuul's required-projects:
+      # ara_tests_ansible_name: "{{ ansible_user_dir }}/src/github.com/ansible/ansible"
+      ara_tests_ansible_name: "ansible"
       ara_tests_ansible_version: null
       ara_api_secure_logging: false
     post-run: tests/zuul_post_logs.yaml

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -72,6 +72,19 @@
       and tests it using the distributed sqlite database backend.
     run: tests/with_distributed_sqlite.yaml
 
+- job:
+    name: ara-role-api-gunicorn-nginx
+    parent: ara-role-integration-base
+    nodeset: ara-multinode
+    description: |
+      Deploys the ARA API server on Ubuntu 18.04, Fedora 32 as well as CentOS 8
+      and tests it running gunicorn with nginx in front managing external
+      authentication.
+      The job exercises the ara_api and ara_frontend_nginx Ansible roles, the
+      ARA Ansible plugins, the ARA API clients as well as the API itself with
+      authentication enabled.
+    run: tests/with_nginx.yaml
+
 # TODO: The job should build a package from current source and test that package
 # instead of the package in the stable distribution.
 - job:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -5,6 +5,7 @@
         - ara-role-api-distributed-sqlite
         - ara-role-api-mysql
         - ara-role-api-postgresql
+        - ara-role-api-gunicorn-nginx
         - ara-role-api-fedora-packages:
             voting: false
     gate:
@@ -12,3 +13,4 @@
         - ara-role-api-distributed-sqlite
         - ara-role-api-mysql
         - ara-role-api-postgresql
+        - ara-role-api-gunicorn-nginx

--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -105,7 +105,24 @@ ara_api_settings: "{{ ara_api_base_dir }}/settings.yaml"
 ara_api_env: default
 
 # ARA_EXTERNAL_AUTH - External authentication settings
+# Read more about setting up authentication in the documentation:
+# https://ara.readthedocs.io/en/latest/api-security.html
 ara_api_external_auth: false
+
+# Path to a .htpasswd file that will be managed by the role if ara_api_external_auth is true.
+ara_api_external_auth_file: /etc/nginx/.htpasswd
+
+# A list of usernames and passwords to encrypt into a .htpasswd file like so:
+# ara_nginx_external_auth_users:
+#   - username: ara
+#     password: hunter2
+#   - username: admin
+#     password: *******
+#
+# The role does NOT supply a default: it must be provided if ara_api_external_auth is enabled.
+# They can be provided in clear text but it is recommended to use ansible-vault so ara doesn't record them.
+# https://docs.ansible.com/ansible/latest/user_guide/vault.html
+ara_api_external_auth_users: []
 
 # ARA_READ_LOGIN_REQUIRED - Whether authentication is required for reading data
 ara_api_read_login_required: false

--- a/roles/ara_api/tasks/install/distribution.yaml
+++ b/roles/ara_api/tasks/install/distribution.yaml
@@ -28,6 +28,15 @@
     name: "{{ ara_distribution_packages }}"
     state: present
 
+# TODO: consider putting the name of the package into a variable if distributions
+# other than fedora become supported.
+- name: Install python-passlib for managing authentication credentials
+  become: yes
+  package:
+    name: python3-passlib
+    state: present
+  when: ara_api_external_auth
+
 # This lets us use "path_with_virtualenv" without conditions everywhere
 - name: Don't prefix the virtualenv bin directory to PATH
   set_fact:

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -8,6 +8,14 @@
     virtualenv_command: /usr/bin/python3 -m venv
   notify: restart ara-api
 
+- name: Install python-passlib for managing authentication credentials
+  pip:
+    name: passlib
+    state: present
+    virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
+    virtualenv_command: /usr/bin/python3 -m venv
+  when: ara_api_external_auth
+
 - name: Prefix the virtualenv bin directory to PATH
   set_fact:
     path_with_virtualenv: "{{ ara_api_venv_path }}/bin:{{ ansible_facts['env']['PATH'] }}"

--- a/roles/ara_api/tasks/install/source.yaml
+++ b/roles/ara_api/tasks/install/source.yaml
@@ -29,6 +29,14 @@
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv
 
+- name: Install python-passlib for managing authentication credentials
+  pip:
+    name: passlib
+    state: present
+    virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
+    virtualenv_command: /usr/bin/python3 -m venv
+  when: ara_api_external_auth
+
 - name: Prefix the virtualenv bin directory to PATH
   set_fact:
     path_with_virtualenv: "{{ ara_api_venv_path }}/bin:{{ ansible_facts['env']['PATH'] }}"

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -27,9 +27,22 @@
 
 # Only attempt to elevate privileges if there are any missing packages
 - when: ara_api_missing_packages | length > 0
+  become: yes
   block:
+    # The apt module can not be used for this since it installs python-apt
+    # which may not work until this command fixes the cache.
+    - name: Update apt cache
+      command: apt-get update
+      when: ansible_facts["os_family"] == "Debian"
+
+    - name: Update yum/dnf cache
+      command: "{{ item }}"
+      loop:
+        - "{{ ansible_pkg_mgr }} clean all"
+        - "{{ ansible_pkg_mgr }} makecache"
+      when: ansible_facts["os_family"] == "RedHat"
+
     - name: Install required packages
-      become: yes
       package:
         name: "{{ ara_api_required_packages }}"
         state: present

--- a/roles/ara_frontend_nginx/handlers/main.yaml
+++ b/roles/ara_frontend_nginx/handlers/main.yaml
@@ -21,4 +21,3 @@
   service:
     name: nginx
     state: restarted
-  when: ara_nginx_enabled is not changed

--- a/roles/ara_frontend_nginx/tasks/main.yaml
+++ b/roles/ara_frontend_nginx/tasks/main.yaml
@@ -38,6 +38,23 @@
 
     - when: ara_api_fqdn is defined
       block:
+        # TODO: htpasswd has moved to community.general
+        # https://github.com/ansible/ansible/blob/7450e87615b0d9b1503a0f966bd3327901decb75/lib/ansible/config/ansible_builtin_runtime.yml#L3195-L3196
+        - name: Configure users in .htpasswd for authentication
+          vars:
+            # htpasswd requires passlib which is installed for the same python interpreter as ara
+            ansible_python_interpreter: "{{ ara_api_venv | bool | ternary(ara_api_venv_path + '/bin/python3', '/usr/bin/python3') }}"
+          htpasswd:
+            path: "{{ ara_api_external_auth_file }}"
+            username: "{{ item.username }}"
+            password: "{{ item.password }}"
+            owner: "{{ ara_nginx_user }}"
+            group: "{{ ara_nginx_group }}"
+            mode: 0600
+          loop: "{{ ara_api_external_auth_users }}"
+          no_log: "{{ ara_api_secure_logging }}"
+          when: ara_api_external_auth
+
         - name: Set up the ARA API nginx vhost
           template:
             src: "{{ ara_api_frontend_vhost | default('ara-api.conf.j2', True) }}"

--- a/roles/ara_frontend_nginx/tasks/main.yaml
+++ b/roles/ara_frontend_nginx/tasks/main.yaml
@@ -94,4 +94,3 @@
         name: nginx
         state: started
         enabled: yes
-      register: ara_nginx_enabled

--- a/roles/ara_frontend_nginx/tasks/main.yaml
+++ b/roles/ara_frontend_nginx/tasks/main.yaml
@@ -89,7 +89,10 @@
           notify:
             - restart nginx
 
-    - name: Enable and start nginx
+    - name: Ensure nginx is restarted if need be
+      meta: flush_handlers
+
+    - name: Ensure nginx is started and enabled
       service:
         name: nginx
         state: started

--- a/roles/ara_frontend_nginx/templates/ara-api.conf.j2
+++ b/roles/ara_frontend_nginx/templates/ara-api.conf.j2
@@ -13,11 +13,6 @@ server {
     access_log /var/log/nginx/{{ ara_api_fqdn }}_access.log;
     error_log  /var/log/nginx/{{ ara_api_fqdn }}_error.log;
 
-    # There's nothing at /, redirect it to the actual API for convenience
-    location = / {
-      return 301 http://{{ ara_api_fqdn }}/api/v1/;
-    }
-
     location /static {
         expires 7d;
         add_header Cache-Control "public";

--- a/roles/ara_frontend_nginx/templates/ara-api.conf.j2
+++ b/roles/ara_frontend_nginx/templates/ara-api.conf.j2
@@ -8,6 +8,11 @@ server {
     listen 80;
     keepalive_timeout 5;
     server_name {{ ara_api_fqdn }};
+    {% if ara_api_external_auth -%}
+    auth_basic "Privileged access";
+    # A .htpasswd file
+    auth_basic_user_file {{ ara_api_external_auth_file }};
+    {% endif %}
 
     client_max_body_size {{ ara_nginx_client_max_body_size }};
     access_log /var/log/nginx/{{ ara_api_fqdn }}_access.log;

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -76,16 +76,28 @@
   include_tasks: zuul_metadata.yaml
   when: zuul is defined
 
+- name: Template an ansible.cfg file
+  copy:
+    content: |
+      [defaults]
+      action_plugins = {{ ara_setup_plugins.stdout }}/action
+      callback_plugins = {{ ara_setup_plugins.stdout }}/callback
+      lookup_plugins = {{ ara_setup_plugins.stdout }}/lookup
+
+      [ara]
+      api_client = {{ ara_api_client | default('offline') }}
+      api_server = {{ ara_api_server | default('http://127.0.0.1:8000') }}
+      callback_threads = {{ ara_callback_threads | default(1) }}
+      {% if _default_labels is defined %}
+      default_labels = {{ _default_labels | join(',') }}
+      {% endif %}
+    dest: "{{ ara_api_root_dir }}/server/ansible.cfg"
+
 # These aren't in the same task (i.e, with loop) so we can tell individual test
 # runs apart easily rather than keeping all the output bundled in a single task.
 - environment:
-    ANSIBLE_CALLBACK_PLUGINS: "{{ ara_setup_plugins.stdout }}/callback"
-    ANSIBLE_ACTION_PLUGINS: "{{ ara_setup_plugins.stdout }}/action"
-    ANSIBLE_LOOKUP_PLUGINS: "{{ ara_setup_plugins.stdout }}/lookup"
+    ANSIBLE_CONFIG: "{{ ara_api_root_dir }}/server/ansible.cfg"
     ARA_SETTINGS: "{{ ara_api_settings }}"
-    ARA_API_CLIENT: "{{ ara_api_client | default('offline') }}"
-    ARA_API_SERVER: "{{ ara_api_server | default('http://127.0.0.1:8000') }}"
-    ARA_DEFAULT_LABELS: "{{ _default_labels | join(', ') | default('default-label') }}"
     PATH: "{{ path_with_virtualenv | default('/usr/bin:/usr/local/bin') }}"
   vars:
     _test_root: "{{ ara_api_source_checkout }}/tests/integration"

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -130,8 +130,10 @@
         executable: /bin/bash
       ignore_errors: yes
 
+  always:
+    # Generate a report even if we had a failure in the playbooks above
     - name: Generate static report
       command: ara-manage generate {{ ara_api_root_dir }}/server/static
 
-- name: List static report files
-  command: ls -alR {{ ara_api_root_dir }}/server/static
+    - name: List static report files
+      command: ls -alR {{ ara_api_root_dir }}/server/static

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -87,6 +87,12 @@
       [ara]
       api_client = {{ ara_api_client | default('offline') }}
       api_server = {{ ara_api_server | default('http://127.0.0.1:8000') }}
+      {% if ara_api_username is defined and ara_api_username %}
+      api_username = {{ ara_api_username }}
+      {% endif %}
+      {% if ara_api_password is defined and ara_api_password %}
+      api_password = {{ ara_api_password }}
+      {% endif %}
       callback_threads = {{ ara_callback_threads | default(1) }}
       {% if _default_labels is defined %}
       default_labels = {{ _default_labels | join(',') }}

--- a/tests/vars/distributed_sqlite_tests.yaml
+++ b/tests/vars/distributed_sqlite_tests.yaml
@@ -1,5 +1,6 @@
 ara_tests_cleanup: true
 ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
+ara_api_database_conn_max_age: 0
 ara_api_distributed_sqlite_root: "{{ ansible_user_dir }}/.ara-tests"
 ara_api_distributed_sqlite_prefix: ara-test-report
 ara_api_wsgi_server: gunicorn

--- a/tests/vars/mysql_tests.yaml
+++ b/tests/vars/mysql_tests.yaml
@@ -3,8 +3,7 @@ ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
 ara_api_secret_key: testing
 ara_api_debug: true
 ara_api_log_level: DEBUG
-# Set to 0 because tests could be using the offline client
-ara_api_database_conn_max_age: 0
+ara_api_database_conn_max_age: 60
 ara_api_database_engine: django.db.backends.mysql
 ara_api_database_name: ara
 ara_api_database_user: ara

--- a/tests/vars/nginx_tests.yaml
+++ b/tests/vars/nginx_tests.yaml
@@ -1,0 +1,31 @@
+ara_tests_cleanup: true
+ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
+ara_api_secret_key: testing
+ara_api_debug: true
+ara_api_log_level: DEBUG
+# disable no_log for potentially sensitive tasks in order to troubleshoot them in integration tests
+ara_api_secure_logging: false
+# Configure cleanup crons to exercise the code path during tests
+ara_api_configure_cron: true
+
+# Set up gunicorn with nginx in front for external authentication
+# TODO: add ssl support https://github.com/ansible-community/ara-collection/issues/37
+ara_api_fqdn: 127.0.0.1
+ara_api_allowed_hosts:
+  - "{{ ara_api_fqdn }}"
+
+ara_api_wsgi_server: gunicorn
+ara_api_frontend_server: nginx
+
+# Configuration to the callback plugin
+ara_api_client: http
+ara_api_server: http://127.0.0.1
+ara_api_username: ara
+ara_api_password: hunter2
+
+# Enable external authentication and set up /etc/nginx/.htpasswd
+ara_api_external_auth: true
+ara_api_external_auth_file: /etc/nginx/.htpasswd
+ara_api_external_auth_users:
+  - username: "{{ ara_api_username }}"
+    password: "{{ ara_api_password }}"

--- a/tests/vars/postgresql_tests.yaml
+++ b/tests/vars/postgresql_tests.yaml
@@ -3,8 +3,7 @@ ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
 ara_api_secret_key: testing
 ara_api_debug: true
 ara_api_log_level: DEBUG
-# Set to 0 because tests could be using the offline client
-ara_api_database_conn_max_age: 0
+ara_api_database_conn_max_age: 60
 ara_api_database_engine: django.db.backends.postgresql
 ara_api_database_name: ara
 ara_api_database_user: ara

--- a/tests/with_nginx.yaml
+++ b/tests/with_nginx.yaml
@@ -1,0 +1,18 @@
+---
+# Copyright (c) 2021 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Deploy and test ARA API with nginx and authentication enabled
+  hosts: ara-api-server
+  gather_facts: yes
+  vars_files:
+    - vars/nginx_tests.yaml
+  tasks:
+    - name: Set up the API with the ara_api Ansible role
+      include_role:
+        name: ara_api
+        public: yes
+
+    # These are tasks rather than a standalone playbook to give us an easy
+    # access to all the variables within the same play.
+    - include_tasks: test_tasks.yaml


### PR DESCRIPTION
This includes drive-by fixes but it's mostly about adding support for managing external authentication via a .htpasswd file in nginx as per the documentation: https://ara.readthedocs.io/en/latest/api-security.html#authentication-and-user-management

The PR also includes a new integration test which covers a large gap that we had in testing -- it will set up gunicorn with nginx in front managing the authentication.