### PR TITLE
galaxy: Add a meta/runtime.yml file

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.9.24'


### PR DESCRIPTION
This is now necessary when uploading collections to galaxy.
Although it may work with other versions of Ansible, use the latest 2.9
for now.