### PR TITLE
Remove yum makecache and removed warnings

### DIFF
--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -36,7 +36,9 @@
       when: ansible_facts["os_family"] == "Debian"
 
     - name: Update yum/dnf cache
-      command: {{ ansible_pkg_mgr }} clean all
+      shell: |
+        {{ ansible_pkg_mgr }} clean all
+        {{ ansible_pkg_mgr }} check-update
       args:
         warn: false
       when: ansible_facts["os_family"] == "RedHat"

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -39,6 +39,8 @@
       shell: |
         {{ ansible_pkg_mgr }} clean all
         {{ ansible_pkg_mgr }} check-update
+      register: yum_update
+      failed_when: yum_update['rc'] not in [0, 100]
       args:
         warn: false
       when: ansible_facts["os_family"] == "RedHat"

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -36,10 +36,9 @@
       when: ansible_facts["os_family"] == "Debian"
 
     - name: Update yum/dnf cache
-      command: "{{ item }}"
-      loop:
-        - "{{ ansible_pkg_mgr }} clean all"
-        - "{{ ansible_pkg_mgr }} makecache"
+      command: {{ ansible_pkg_mgr }} clean all
+      args:
+        warn: false
       when: ansible_facts["os_family"] == "RedHat"
 
     - name: Install required packages


### PR DESCRIPTION
This PR removes ```yum/dnf makecache``` from the task list, this is because it can create a rather big database in Satellite enabled environments (12GB+) which is completely not necessary.

Also the RedHat suggests to avoid running it where possible: https://access.redhat.com/solutions/5302591

And AFAIK replacing it with check-update will also refresh the cache :-)