### PR TITLE
This will force the use of pip3 when not running in a venv

### DIFF
--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -5,6 +5,7 @@
     state: "{{ (ara_api_version == 'latest') | ternary('latest', 'present') }}"
     version: "{{ (ara_api_version != 'latest') | ternary(ara_api_version, omit) }}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
+    executable: "{{ ara_api_venv | bool | ternary(omit, '/bin/pip3') }}"
     virtualenv_command: /usr/bin/python3 -m venv
   notify: restart ara-api
 

--- a/roles/ara_api/tasks/main.yaml
+++ b/roles/ara_api/tasks/main.yaml
@@ -23,6 +23,11 @@
     - "{{ ansible_facts['distribution'] }}.yaml"
     - "{{ ansible_facts['os_family'] }}.yaml"
 
+- name: Prime path_with_virtualenv when not using venvs
+  set_fact:
+    path_with_virtualenv: "{{ ansible_facts['env']['PATH'] }}"
+  when: not ara_api_venv | bool
+
 - name: Ensure pre-requirements for running are met
   include_tasks: pre-requirements.yaml
 

--- a/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
+++ b/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
@@ -21,6 +21,7 @@
     name: gunicorn
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
+    executable: "{{ ara_api_venv | bool | ternary(omit, '/bin/pip3') }}"
     virtualenv_command: /usr/bin/python3 -m venv
 
 - name: Get path to gunicorn


### PR DESCRIPTION
I forgot to implement this first time around :-)

This will actually force the use of pip3 when not running in a venv (RHEL7 is an example where this is a lot of pain and suffering)