### PR TITLE
Added RedHat/CentOS support for Nodesource repo

### DIFF
--- a/roles/ara_web/defaults/main.yaml
+++ b/roles/ara_web/defaults/main.yaml
@@ -54,6 +54,9 @@ ara_web_dev_server_bind_port: 3000
 # Version of nodesource nodejs repositories to install
 ara_web_nodejs_version: 10
 
+# Disable gpgcheck for installation of nodesource repository
+ara_web_nodejs_gpgcheck: no
+
 # ara-server API endpoint to use
 ara_web_api_endpoint: "http://127.0.0.1:8000"
 

--- a/roles/ara_web/tasks/nodejs.yaml
+++ b/roles/ara_web/tasks/nodejs.yaml
@@ -48,9 +48,10 @@
 
 - name: Install Nodesource yum repository (RedHat/CentOS)
   become: yes
-  package:
+  yum:
     name: "https://rpm.nodesource.com/pub_{{ ara_web_nodejs_version }}.x/el/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/nodesource-release-el{{ ansible_facts['distribution_major_version'] }}-1.noarch.rpm"
     state: present
+    disable_gpg_check: "{{ ara_web_nodejs_gpgcheck }}"
   when: ansible_facts['distribution'] == "RedHat" or ansible_facts['distribution'] == "CentOS"
 
 - name: Install nodejs

--- a/roles/ara_web/tasks/nodejs.yaml
+++ b/roles/ara_web/tasks/nodejs.yaml
@@ -39,12 +39,19 @@
         state: present
         update_cache: yes
 
-- name: Install Nodesource yum repository
+- name: Install Nodesource yum repository (Fedora)
   become: yes
   package:
     name: "https://rpm.nodesource.com/pub_{{ ara_web_nodejs_version }}.x/fc/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/nodesource-release-fc{{ ansible_facts['distribution_major_version'] }}-1.noarch.rpm"
     state: present
-  when: ansible_facts['os_family'] == "RedHat"
+  when: ansible_facts['distribution'] == "Fedora"
+
+- name: Install Nodesource yum repository (RedHat/CentOS)
+  become: yes
+  package:
+    name: "https://rpm.nodesource.com/pub_{{ ara_web_nodejs_version }}.x/el/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/nodesource-release-el{{ ansible_facts['distribution_major_version'] }}-1.noarch.rpm"
+    state: present
+  when: ansible_facts['distribution'] == "RedHat" or ansible_facts['distribution'] == "CentOS"
 
 - name: Install nodejs
   become: yes


### PR DESCRIPTION
Split installation task of Nodesource yum repository from entire RedHat os_family into 2 seperate tasks: 1 for Fedora and 1 for RedHat/CentOS.

Reason: Installation of Nodesource yum repository didn't work for RHEL.