### PR TITLE
Add integration test for `api_(cert|key|ca)` options

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -85,6 +85,19 @@
       authentication enabled.
     run: tests/with_nginx.yaml
 
+- job:
+    name: ara-role-api-gunicorn-nginx-client-cert
+    parent: ara-role-integration-base
+    nodeset: ara-multinode
+    description: |
+      Deploys the ARA API server on Ubuntu 18.04, Fedora 32 as well as CentOS 8
+      and tests it running gunicorn with nginx in front managing external
+      authentication with client certificates.
+      The job exercises the ara_api and ara_frontend_nginx Ansible roles, the
+      ARA Ansible plugins, the ARA API clients as well as the API itself with
+      authentication enabled.
+    run: tests/with_client_cert.yaml
+
 # TODO: The job should build a package from current source and test that package
 # instead of the package in the stable distribution.
 - job:

--- a/roles/ara_frontend_nginx/templates/ara-api-ssl.conf.j2
+++ b/roles/ara_frontend_nginx/templates/ara-api-ssl.conf.j2
@@ -32,6 +32,10 @@ server {
     ssl_session_timeout 10m;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         EECDH+AESGCM:EDH+AESGCM;
+{% if ara_api_frontend_ca_cert is defined %}
+    ssl_client_certificate {{ ara_api_frontend_ca_cert }};
+    ssl_verify_client on;
+{% endif }
 
     location /static {
         expires 7d;

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -94,6 +94,15 @@
       {% if ara_api_password is defined and ara_api_password %}
       api_password = {{ ara_api_password }}
       {% endif %}
+      {% if ara_api_cert is defined and ara_api_cert %}
+      api_cert = {{ ara_api_cert }}
+      {% endif %}
+      {% if ara_api_key is defined and ara_api_key %}
+      api_key = {{ ara_api_key }}
+      {% endif %}
+      {% if ara_api_ca is defined and ara_api_ca %}
+      api_ca = {{ ara_api_ca }}
+      {% endif %}
       callback_threads = {{ ara_callback_threads | default(1) }}
       {% if _default_labels is defined %}
       default_labels = {{ _default_labels | join(',') }}

--- a/tests/vars/nginx_client_cert_tests.yaml
+++ b/tests/vars/nginx_client_cert_tests.yaml
@@ -1,0 +1,7 @@
+---
+ara_api_frontend_ca_cert: /etc/ssl/ara-ca/cert.pem
+ara_api_frontend_ca_key: /etc/ssl/ara-ca/privkey.pem
+
+ara_api_ca: "{{ ara_api_frontend_ca_cert }}"
+ara_api_cert: /etc/ssl/ara-client/cert.pem
+ara_api_key: /etc/ssl/ara-client/privkey.pem

--- a/tests/vars/nginx_tests.yaml
+++ b/tests/vars/nginx_tests.yaml
@@ -19,8 +19,7 @@ ara_api_frontend_server: nginx
 ara_api_frontend_ssl: true
 ara_api_frontend_ssl_key: /etc/ssl/ara.example.org/privkey.pem
 ara_api_frontend_ssl_cert: /etc/ssl/ara.example.org/cert.pem
-# TODO: Make the callback trust the certificate
-ara_api_insecure: 'true'
+ara_api_ca: "{{ ara_api_frontend_ssl_cert }}"
 
 # Configuration to the callback plugin
 ara_api_client: http

--- a/tests/with_client_cert.yaml
+++ b/tests/with_client_cert.yaml
@@ -1,0 +1,150 @@
+---
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Deploy and test ARA API with nginx, client certificates required
+  hosts: ara-api-server
+  gather_facts: yes
+  vars_files:
+    - vars/nginx_tests.yaml
+    - vars/nginx_client_cert_tests.yaml
+  pre_tasks:
+    - become: true
+      block:
+        - name: "Set {{ ara_api_fqdn }} to 127.0.0.1"
+          lineinfile:
+            path: /etc/hosts
+            line: "127.0.0.1 {{ ara_api_fqdn }}"
+
+        - name: Ensure directory for SSL certificate and private key exists
+          file:
+            path: "{{ item | dirname }}"
+            state: directory
+            recurse: yes
+          loop:
+            - "{{ ara_api_frontend_ssl_key }}"
+            - "{{ ara_api_frontend_ssl_cert }}"
+            - "{{ ara_api_frontend_ca_key }}"
+            - "{{ ara_api_frontend_ca_certe }}"
+            - "{{ ara_api_client_key }}"
+            - "{{ ara_api_client_cert }}"
+
+        - name: Set path to openssl configuration files
+          set_fact:
+            _selfsigned_conf: "{{ ara_api_frontend_ssl_key | dirname }}/selfsigned.conf"
+            _selfsigned_ext_conf: "{{ ara_api_frontend_ssl_key | dirname }}/selfsigned_ext.conf"
+
+        # Generate a self-signed certificate over shell
+        # community.crypto requires python cryptography to be installed (on the remote note)
+        - name: Template the openssl configuration file for the CA
+          copy:
+            dest: "{{ _selfsigned_conf }}"
+            content: |
+              [ req ]
+              default_bits       = 2048
+              default_keyfile    = {{ ara_api_frontend_ca_key }}
+              default_md         = sha256
+              prompt             = no
+              distinguished_name = distinguished_name
+              x509_extensions    = v3_ca
+
+              [ v3_ca ]
+              basicConstraints       = CA:TRUE
+              subjectKeyIdentifier   = hash
+              authorityKeyIdentifier = keyid:always,issuer:always
+
+              [ distinguished_name ]
+              commonName             = ARA Test CA
+              countryName            = CA
+              stateOrProvinceName    = QC
+              localityName           = Montreal
+              organizationName       = ara
+              organizationalUnitName = integration-tests
+
+        - name: Generate the CA private key and self-signed certificate
+          command: >-
+            openssl req
+            -x509
+            -config {{ _selfsigned_conf }}
+            -newkey rsa:2048
+            -keyform PEM
+            -out {{ ara_api_frontend_ca_cert }}
+            -outform PEM
+            -days 3650
+            -nodes
+
+        - name: Generate client/server certificates
+          block:
+            - name: Set the CSR file
+                _csr_file: "{{ item.cert_file | regex_replace('.pem$', '.csr') }}"
+
+            - name: Template the openssl configuration file
+              copy:
+                dest: "{{ _selfsigned_conf }}"
+                content: |
+                  [ req ]
+                  default_bits       = 2048
+                  default_keyfile    = {{ item.key_file }}
+                  default_md         = sha256
+                  prompt             = no
+                  distinguished_name = distinguished_name
+                  x509_extensions    = v3_ca
+
+                  [ v3_ca ]
+                  basicConstraints       = critical,CA:FALSE
+                  extendedKeyUsage       = critical,{{ item.eku }}
+                  subjectKeyIdentifier   = hash
+                  authorityKeyIdentifier = keyid:always,issuer:always
+
+                  [ distinguished_name ]
+                  commonName             = {{ item.common_name }}
+                  countryName            = CA
+                  stateOrProvinceName    = QC
+                  localityName           = Montreal
+                  organizationName       = ara
+                  organizationalUnitName = integration-tests
+
+            - name: Generate a CSR
+              command: >-
+                openssl req
+                -config {{ _selfsigned_conf | quote }}
+                -newkey rsa:2048
+                -keyform PEM
+                -out {{ _csr_file | quote }}
+                -outform PEM
+                -nodes
+
+            - name: Template ext file
+              copy:
+                dest: "{{ _selfsigned_ext_conf }}"
+                content: |
+                  subjectAltName=DNS:{{ item.common_name }}
+
+            - name: Sign the CSR with our CA
+              command: >-
+                openssl x509
+                -req
+                -in {{ _csr_file | quote }}
+                -CA {{ ara_api_frontend_ca_cert | quote }}
+                -CAkey {{ ara_api_frontend_ca_key }}
+                -CAcreateserial
+                -out {{ item.cert_file | quote }}
+                -extfile {{ _selfsigned_ext_conf | quote }}
+          with_items:
+            - common_name: "{{ ara_api_fqdn }}"
+              cert_file: "{{ ara_api_frontend_ssl_cert }}"
+              key_file: "{{ ara_api_frontend_ssl_key }}"
+              eku: serverAuth
+            - common_name: ARA API Client Cert
+              cert_file: "{{ ara_api_cert }}"
+              key_file: "{{ ara_api_key }}"
+              eku: clientAuth
+  tasks:
+    - name: Set up the API with the ara_api Ansible role
+      include_role:
+        name: ara_api
+        public: yes
+
+    # These are tasks rather than a standalone playbook to give us an easy
+    # access to all the variables within the same play.
+    - include_tasks: test_tasks.yaml


### PR DESCRIPTION
This PR:
- modifies the existing NGINX test to use `api_ca` instead of `api_insecure`
- adds a test with NGINX and client certificates

Related: https://github.com/ansible-community/ara/pull/392