### PR TITLE
zuul: bump ansible-core from 2.9 to 2.13

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -36,7 +36,7 @@
       - github.com/ansible-community/ara
       - github.com/ansible-community/ara-collection
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
+        override-checkout: stable-2.13
     pre-run: tests/zuul_pre_multinode_networking.yaml
 
 - job:


### PR DESCRIPTION
2.9 is end of life, bump to 2.13.