### PR TITLE
Fix package deps

### DIFF
--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -25,6 +25,7 @@ ara_distribution_packages: []
 ara_api_required_packages:
   - git
   - python36
+  - python36-devel
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -33,11 +34,8 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
-  - python36-devel
-  - gcc
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
-  - python36-devel

--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -28,6 +28,7 @@ ara_api_required_packages:
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
+  - gcc
 
 ara_api_postgresql_packages:
   - postgresql
@@ -40,4 +41,3 @@ ara_api_mysql_packages:
   - mariadb-connector-c-devel
   - redhat-rpm-config
   - python36-devel
-  - gcc

--- a/roles/ara_api/vars/CentOS_9.yaml
+++ b/roles/ara_api/vars/CentOS_9.yaml
@@ -26,6 +26,7 @@ ara_api_required_packages:
   - git
   # python3.9 on EL9
   - python3
+  - python3-devel
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -34,10 +35,8 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
-  - python3-devel
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
-  - python3-devel

--- a/roles/ara_api/vars/CentOS_9.yaml
+++ b/roles/ara_api/vars/CentOS_9.yaml
@@ -29,16 +29,15 @@ ara_api_required_packages:
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
+  - gcc
 
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
   - python3-devel
-  - gcc
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
   - python3-devel
-  - gcc

--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -27,16 +27,15 @@ ara_api_required_packages:
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
+  - gcc
 
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
   - python3-devel
-  - gcc
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
   - python3-devel
-  - gcc

--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -24,6 +24,7 @@ ara_api_required_packages:
   - git
   - python3-virtualenv
   - python3-libselinux
+  - python3-devel
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -32,10 +33,8 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
-  - python3-devel
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
-  - python3-devel

--- a/roles/ara_api/vars/Ubuntu.yaml
+++ b/roles/ara_api/vars/Ubuntu.yaml
@@ -25,15 +25,14 @@ ara_api_required_packages:
   - python3-setuptools
   - python-pkg-resources
   - python3-pkg-resources
+  - gcc
 
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-server-dev-10
   - python3-dev
-  - gcc
 
 ara_api_mysql_packages:
   - mariadb-client
   - libmariadbclient-dev
   - python3-dev
-  - gcc

--- a/roles/ara_api/vars/Ubuntu.yaml
+++ b/roles/ara_api/vars/Ubuntu.yaml
@@ -23,6 +23,7 @@ ara_api_required_packages:
   - git
   - python3-venv
   - python3-setuptools
+  - python3-dev
   - python-pkg-resources
   - python3-pkg-resources
   - gcc
@@ -30,9 +31,7 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-server-dev-10
-  - python3-dev
 
 ara_api_mysql_packages:
   - mariadb-client
   - libmariadbclient-dev
-  - python3-dev


### PR DESCRIPTION
Pypi dependency Ruamel has changed some things that require the presence of Python headers as well as GCC