### PR TITLE
Made task to collect loaded selinux modules not report as changed

### DIFF
--- a/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
+++ b/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
@@ -57,6 +57,7 @@
       command: semodule -l
       register: ara_selinux_modules_loaded
       when: ansible_facts['os_family'] == "RedHat"
+      changed_when: false
 
     - name: Install selinux policy package
       command: "semodule -i {{ ara_api_root_dir }}/ara-gunicorn.pp"


### PR DESCRIPTION
This makes the task that collects the current SELinux module config silent (ok instead of changed)