### PR TITLE
Debian 12 support

### DIFF
--- a/roles/ara_api/defaults/main.yaml
+++ b/roles/ara_api/defaults/main.yaml
@@ -45,6 +45,9 @@ ara_api_venv_path: "{{ ara_api_root_dir }}/virtualenv"
 # - pypi : installs from pypi
 ara_api_install_method: source
 
+# If installing from pypi: include system packages in venv
+ara_api_venv_use_system_packages: false
+
 # When installing from source, the URL or filesystem path where the git source
 # repository can be cloned from.
 ara_api_source: "https://github.com/ansible-community/ara"

--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -42,7 +42,7 @@
   pip:
     # Pin psycopg2 until we upgrade to django 3.2 LTS
     # https://github.com/ansible-community/ara/issues/320
-    name: psycopg2<2.9
+    name: psycopg2<3
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -6,6 +6,7 @@
     version: "{{ (ara_api_version != 'latest') | ternary(ara_api_version, omit) }}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_site_packages: "{{ ara_api_venv_use_system_packages }}"
   notify: restart ara-api
 
 - name: Install python-passlib for managing authentication credentials

--- a/roles/ara_api/vars/Debian_12.yaml
+++ b/roles/ara_api/vars/Debian_12.yaml
@@ -1,0 +1,35 @@
+---
+#  Copyright (c) 2019 Red Hat, Inc.
+#
+#  This file is part of ARA Records Ansible.
+#
+#  ARA Records Ansible is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA Records Ansible is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA Records Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+# ARA has not been packaged for Debian yet
+ara_distribution_packages: []
+
+ara_api_required_packages:
+  - git
+  - python3-venv
+  - python3-setuptools
+  - python3-pkg-resources
+
+ara_api_postgresql_packages:
+  - python3-psycopg2
+
+ara_api_mysql_packages:
+  - mariadb-client
+  - libmariadbclient-dev
+  - python3-dev
+  - gcc


### PR DESCRIPTION
* support using system packages in installation venv
* changed version pinning of psycopg2 to reflect the comment
* updated package dependencies for Debian 12

Tested with pypi installation method, postgresql backend using Debian's package python3-psycopg2 (version 2.9.5-1+b1).