### PR TITLE
Make the version of Python used by ARA configurable

### DIFF
--- a/roles/ara_api/tasks/config.yaml
+++ b/roles/ara_api/tasks/config.yaml
@@ -50,7 +50,7 @@
     - name: Generate a random secret key
       environment:
         PATH: "{{ path_with_virtualenv }}"
-      command: python3 -c "from django.utils.crypto import get_random_string; print(get_random_string(length=50))"
+      command: "{{ ara_api_python_command }} -c 'from django.utils.crypto import get_random_string; print(get_random_string(length=50))'"
       no_log: "{{ ara_api_secure_logging }}"
       register: generated_key
 

--- a/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
@@ -43,7 +43,7 @@
     name: mysqlclient
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv
 
 - name: Run SQL migrations
   environment:

--- a/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
@@ -43,7 +43,7 @@
     name: mysqlclient
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: "{{ ara_api_python_command }} -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Run SQL migrations
   environment:

--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -45,7 +45,7 @@
     name: psycopg2<2.9
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Run SQL migrations
   environment:

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -5,7 +5,7 @@
     state: "{{ (ara_api_version == 'latest') | ternary('latest', 'present') }}"
     version: "{{ (ara_api_version != 'latest') | ternary(ara_api_version, omit) }}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   notify: restart ara-api
 
 - name: Install python-passlib for managing authentication credentials
@@ -13,7 +13,7 @@
     name: passlib
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   when: ara_api_external_auth
 
 - name: Prefix the virtualenv bin directory to PATH

--- a/roles/ara_api/tasks/install/source.yaml
+++ b/roles/ara_api/tasks/install/source.yaml
@@ -27,14 +27,14 @@
     name: "{{ ara_api_source_checkout }}[server]"
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Install python-passlib for managing authentication credentials
   pip:
     name: passlib
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   when: ara_api_external_auth
 
 - name: Prefix the virtualenv bin directory to PATH

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -60,7 +60,7 @@
 # The ansible_python_version fact might end up retrieving the version of
 # python2 so we need to explicitely get the version of python 3 available.
 - name: Validate availability of Python 3.5
-  command: "{{ ara_api_python_command }} -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'"
+  command: "{{ ara_api_python_command }} -c 'import sys; print(\".\".join(map(str, sys.version_info[:2])))'"
   changed_when: false
   failed_when: false
   register: python_version

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -60,7 +60,7 @@
 # The ansible_python_version fact might end up retrieving the version of
 # python2 so we need to explicitely get the version of python 3 available.
 - name: Validate availability of Python 3.5
-  command: /usr/bin/python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'
+  command: "{{ ara_api_python_command }} -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'"
   changed_when: false
   failed_when: false
   register: python_version

--- a/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
+++ b/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
@@ -21,7 +21,7 @@
     name: gunicorn
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Get path to gunicorn
   command: which gunicorn

--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -42,4 +42,4 @@ ara_api_mysql_packages:
   - python36-devel
   - gcc
 
-ara_api_python_command: /usr/bin/python39
+ara_api_python_command: /usr/bin/python3.9

--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -24,7 +24,7 @@ ara_distribution_packages: []
 # but we want to use the non-system one. Install it if it's missing.
 ara_api_required_packages:
   - git
-  - python36
+  - python39
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -41,3 +41,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python36-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python39

--- a/roles/ara_api/vars/CentOS_9.yaml
+++ b/roles/ara_api/vars/CentOS_9.yaml
@@ -42,3 +42,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python3-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python3

--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -40,3 +40,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python3-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python3

--- a/roles/ara_api/vars/Ubuntu.yaml
+++ b/roles/ara_api/vars/Ubuntu.yaml
@@ -37,3 +37,5 @@ ara_api_mysql_packages:
   - libmariadbclient-dev
   - python3-dev
   - gcc
+
+ara_api_python_command: /usr/bin/python3


### PR DESCRIPTION
Allow different distro's to use different version of the Python Interpreter for running venv commands

Fixes https://github.com/ansible-community/ara/issues/527