### PR TITLE
maintenance: update & fix CI, bump python >=3.8, bump postgresql >= 12

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -36,7 +36,7 @@
       - github.com/ansible-community/ara
       - github.com/ansible-community/ara-collection
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.13
+        override-checkout: stable-2.16
     pre-run: tests/zuul_pre_multinode_networking.yaml
 
 - job:
@@ -44,7 +44,7 @@
     parent: ara-role-database-backends
     nodeset: ara-database-server-multinode
     description: |
-      Deploys the ARA API server on Fedora 36 as well as CentOS Stream 8/9
+      Deploys the ARA API server on Fedora 39 as well as CentOS Stream 8/9
       and tests it against a central PostgreSQL server installed on CentOS Stream 9.
       The job exercises the ara_api Ansible role, the ARA Ansible plugins, the
       ARA API clients as well as the API itself.
@@ -56,7 +56,7 @@
     parent: ara-role-database-backends
     nodeset: ara-database-server-multinode
     description: |
-      Deploys the ARA API server on Fedora 36 as well as CentOS Stream 8/9
+      Deploys the ARA API server on Fedora 39 as well as CentOS Stream 8/9
       and tests it against a central MySQL server installed on CentOS Stream 9.
       The job exercises the ara_api Ansible role, the ARA Ansible plugins, the
       ARA API clients as well as the API itself.
@@ -68,7 +68,7 @@
     parent: ara-role-database-backends
     nodeset: ara-multinode
     description: |
-      Deploys the ARA API server on Fedora 36 as well as CentOS Stream 8/9
+      Deploys the ARA API server on Fedora 39 as well as CentOS Stream 8/9
       and tests it using the distributed sqlite database backend.
     run: tests/with_distributed_sqlite.yaml
 
@@ -77,7 +77,7 @@
     parent: ara-role-integration-base
     nodeset: ara-multinode
     description: |
-      Deploys the ARA API server on Fedora 36 as well as CentOS Stream 8/9
+      Deploys the ARA API server on Fedora 39 as well as CentOS Stream 8/9
       and tests it running gunicorn with nginx in front managing external
       authentication.
       The job exercises the ara_api and ara_frontend_nginx Ansible roles, the
@@ -90,7 +90,7 @@
     parent: ara-role-integration-base
     nodeset: ara-multinode
     description: |
-      Deploys the ARA API server on Fedora 36 as well as CentOS Stream 8/9
+      Deploys the ARA API server on Fedora 39 as well as CentOS Stream 8/9
       and tests it running gunicorn with nginx in front managing external
       authentication with client certificates.
       The job exercises the ara_api and ara_frontend_nginx Ansible roles, the
@@ -103,7 +103,7 @@
 - job:
     name: ara-role-api-fedora-packages
     parent: ara-role-integration-base
-    nodeset: ara-fedora-36
+    nodeset: ara-fedora-39
     description: |
       Deploys the ARA API server on Fedora 36 using distribution packages for
       ARA and Ansible.

--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -4,13 +4,13 @@
     name: ara-database-server-multinode
     nodes:
       - name: database-server
-        label: ansible-cloud-centos-9-stream-tiny
-      - name: fedora-36
-        label: ansible-cloud-fedora-36-tiny
+        label: cloud-centos-9-stream
+      - name: fedora-39
+        label: cloud-fedora-39
       - name: centos-stream-9
-        label: ansible-cloud-centos-9-stream-tiny
+        label: cloud-centos-9-stream
       - name: centos-stream-8
-        label: ansible-cloud-centos-8-stream-tiny
+        label: cloud-centos-8-stream
       # TODO: lacking ubuntu/debian testing coverage because there is no ubuntu image in CI
       #- name: ubuntu-bionic
       #  label: ubuntu-bionic-1vcpu
@@ -20,7 +20,7 @@
           - database-server
       - name: ara-api-server
         nodes:
-          - fedora-36
+          - fedora-39
           - centos-stream-9
           - centos-stream-8
           # - ubuntu-bionic
@@ -30,29 +30,29 @@
 - nodeset:
     name: ara-multinode
     nodes:
-      - name: fedora-36
-        label: ansible-cloud-fedora-36-tiny
+      - name: fedora-39
+        label: cloud-fedora-39
       - name: centos-stream-9
-        label: ansible-cloud-centos-9-stream-tiny
+        label: cloud-centos-9-stream
       - name: centos-stream-8
-        label: ansible-cloud-centos-8-stream-tiny
+        label: cloud-centos-8-stream
       # TODO: lacking ubuntu/debian testing coverage because there is no ubuntu image in CI
       #- name: ubuntu-bionic
       #  label: ubuntu-bionic-1vcpu
     groups:
       - name: ara-api-server
         nodes:
-          - fedora-36
+          - fedora-39
           - centos-stream-9
           - centos-stream-8
           # - ubuntu-bionic
 
 - nodeset:
-    name: ara-fedora-36
+    name: ara-fedora-39
     nodes:
-      - name: fedora-36
-        label: ansible-cloud-fedora-36-tiny
+      - name: fedora-39
+        label: cloud-fedora-39
     groups:
       - name: ara-api-server
         nodes:
-          - fedora-36
+          - fedora-39

--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -47,12 +47,3 @@
           - centos-stream-8
           # - ubuntu-bionic
 
-- nodeset:
-    name: ara-fedora-39
-    nodes:
-      - name: fedora-39
-        label: cloud-fedora-39
-    groups:
-      - name: ara-api-server
-        nodes:
-          - fedora-39

--- a/roles/ara_api/tasks/config.yaml
+++ b/roles/ara_api/tasks/config.yaml
@@ -50,7 +50,7 @@
     - name: Generate a random secret key
       environment:
         PATH: "{{ path_with_virtualenv }}"
-      command: python3 -c "from django.utils.crypto import get_random_string; print(get_random_string(length=50))"
+      command: "{{ ara_api_python_command }} -c 'from django.utils.crypto import get_random_string; print(get_random_string(length=50))'"
       no_log: "{{ ara_api_secure_logging }}"
       register: generated_key
 

--- a/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.mysql.yaml
@@ -43,7 +43,7 @@
     name: mysqlclient
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Run SQL migrations
   environment:

--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -36,13 +36,12 @@
           Install the following packages before running this role again
           {{ _postgresql_missing_packages | join(' ') }}
 
-# Django requires psycopg2 when using postgresql
-# https://docs.djangoproject.com/en/2.2/ref/databases/#postgresql-notes
+# Django requires psycopg2 (or psycopg3) when using postgresql
+# https://docs.djangoproject.com/en/5.0/releases/4.2/#psycopg-3-support
+# TODO: Consider psycopg3: https://github.com/ansible-community/ara-collection/issues/73
 - name: Ensure psycopg2 is installed
   pip:
-    # Pin psycopg2 until we upgrade to django 3.2 LTS
-    # https://github.com/ansible-community/ara/issues/320
-    name: psycopg2<2.9
+    name: psycopg2
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
     virtualenv_command: "{{ ara_api_python_command }} -m venv"

--- a/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
+++ b/roles/ara_api/tasks/database_engine/django.db.backends.postgresql.yaml
@@ -45,7 +45,7 @@
     name: psycopg2<2.9
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Run SQL migrations
   environment:

--- a/roles/ara_api/tasks/install/pypi.yaml
+++ b/roles/ara_api/tasks/install/pypi.yaml
@@ -5,7 +5,7 @@
     state: "{{ (ara_api_version == 'latest') | ternary('latest', 'present') }}"
     version: "{{ (ara_api_version != 'latest') | ternary(ara_api_version, omit) }}"
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   notify: restart ara-api
 
 - name: Install python-passlib for managing authentication credentials
@@ -13,7 +13,7 @@
     name: passlib
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   when: ara_api_external_auth
 
 - name: Prefix the virtualenv bin directory to PATH

--- a/roles/ara_api/tasks/install/source.yaml
+++ b/roles/ara_api/tasks/install/source.yaml
@@ -27,14 +27,14 @@
     name: "{{ ara_api_source_checkout }}[server]"
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Install python-passlib for managing authentication credentials
   pip:
     name: passlib
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
   when: ara_api_external_auth
 
 - name: Prefix the virtualenv bin directory to PATH

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -60,7 +60,7 @@
 # The ansible_python_version fact might end up retrieving the version of
 # python2 so we need to explicitely get the version of python 3 available.
 - name: Validate availability of Python 3.5
-  command: /usr/bin/python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'
+  command: "{{ ara_api_python_command }} -c 'import sys; print(\".\".join(map(str, sys.version_info[:2])))'"
   changed_when: false
   failed_when: false
   register: python_version

--- a/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
+++ b/roles/ara_api/tasks/wsgi_server/gunicorn.yaml
@@ -21,7 +21,7 @@
     name: gunicorn
     state: present
     virtualenv: "{{ ara_api_venv | bool | ternary(ara_api_venv_path, omit) }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ara_api_python_command }} -m venv"
 
 - name: Get path to gunicorn
   command: which gunicorn

--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -32,14 +32,14 @@ ara_api_required_packages:
 ara_api_postgresql_packages:
   - postgresql
   - postgresql-devel
-  - python36-devel
+  - python39-devel
   - gcc
 
 ara_api_mysql_packages:
   - mariadb
   - mariadb-connector-c-devel
   - redhat-rpm-config
-  - python36-devel
+  - python39-devel
   - gcc
 
 ara_api_python_command: /usr/bin/python3.9

--- a/roles/ara_api/vars/CentOS_8.yaml
+++ b/roles/ara_api/vars/CentOS_8.yaml
@@ -24,7 +24,7 @@ ara_distribution_packages: []
 # but we want to use the non-system one. Install it if it's missing.
 ara_api_required_packages:
   - git
-  - python36
+  - python39
   - policycoreutils-python-utils
   # cronie provides crontab
   - cronie
@@ -41,3 +41,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python36-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python3.9

--- a/roles/ara_api/vars/CentOS_9.yaml
+++ b/roles/ara_api/vars/CentOS_9.yaml
@@ -42,3 +42,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python3-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python3

--- a/roles/ara_api/vars/Fedora.yaml
+++ b/roles/ara_api/vars/Fedora.yaml
@@ -40,3 +40,5 @@ ara_api_mysql_packages:
   - redhat-rpm-config
   - python3-devel
   - gcc
+
+ara_api_python_command: /usr/bin/python3

--- a/roles/ara_api/vars/Ubuntu.yaml
+++ b/roles/ara_api/vars/Ubuntu.yaml
@@ -37,3 +37,5 @@ ara_api_mysql_packages:
   - libmariadbclient-dev
   - python3-dev
   - gcc
+
+ara_api_python_command: /usr/bin/python3

--- a/tests/vars/postgresql_tests.yaml
+++ b/tests/vars/postgresql_tests.yaml
@@ -14,4 +14,4 @@ ara_api_configure_cron: true
 # The host is defined dynamically based on the address of the database server
 # ara_api_database_host: 127.0.0.1
 _postgresql_container_name: ara-postgresql-tests
-_postgresql_image_name: docker.io/postgres:10
+_postgresql_image_name: docker.io/postgres:12


### PR DESCRIPTION
- Bump Fedora 36 to 39
- Use cloud images for centos stream 8 and 9