### PR TITLE
Simplify package installation process

### DIFF
--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -16,46 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with ARA Records Ansible. If not, see <http://www.gnu.org/licenses/>.
 
-- name: Get list of installed packages
-  package_facts:
-    manager: "auto"
-  no_log: "{{ ara_api_secure_logging }}"
-
-- name: Retrieve list of missing required packages
-  set_fact:
-    ara_api_missing_packages: "{{ ara_api_required_packages | difference(ansible_facts['packages'].keys()) }}"
-
-# Only attempt to elevate privileges if there are any missing packages
-- when: ara_api_missing_packages | length > 0
+- name: Install required packages
+  package:
+    name: "{{ ara_api_required_packages }}"
+    state: present
+    update_cache: true
   become: true
-  block:
-    - name: Update apt cache
-      command: apt-get update
-      args:
-        warn: false
-      when: ansible_facts["os_family"] == "Debian"
-
-    - name: Update yum/dnf cache
-      shell: |
-        {{ ansible_pkg_mgr }} clean all
-        {{ ansible_pkg_mgr }} check-update
-      register: yum_update
-      failed_when: yum_update['rc'] not in [0, 100]
-      args:
-        warn: false
-      when: ansible_facts["os_family"] == "RedHat"
-
-    - name: Install required packages
-      package:
-        name: "{{ ara_api_required_packages }}"
-        state: present
-  rescue:
-    - name: Fail due to missing packages
-      fail:
-        msg: |
-          Failed to elevate privileges and install missing required packages.
-          Install the following packages before running this role again:
-          {{ ara_missing_packages | join(' ') }}
 
 # The ansible_python_version fact might end up retrieving the version of
 # python2 so we need to explicitely get the version of python 3 available.


### PR DESCRIPTION
Currently, `warn` is passed to `args` argument in a few places. `warn` was removed in ansible 2.14[1] which makes it impossible to use ara_api role with ansible >=2.14.

Patch proposes an easier way to install required packages on all package managers and ensure that their cache is updated.

[1] https://github.com/ansible/ansible/pull/70504