### PR TITLE
Update Zuul to drop CentOS8 and F39

### DIFF
--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -5,12 +5,10 @@
     nodes:
       - name: database-server
         label: cloud-centos-9-stream
-      - name: fedora-39
-        label: cloud-fedora-39
+      - name: fedora-40
+        label: cloud-fedora-40
       - name: centos-stream-9
         label: cloud-centos-9-stream
-      - name: centos-stream-8
-        label: cloud-centos-8-stream
       # TODO: lacking ubuntu/debian testing coverage because there is no ubuntu image in CI
       #- name: ubuntu-bionic
       #  label: ubuntu-bionic-1vcpu
@@ -20,9 +18,8 @@
           - database-server
       - name: ara-api-server
         nodes:
-          - fedora-39
+          - fedora-40
           - centos-stream-9
-          - centos-stream-8
           # - ubuntu-bionic
 
 # Nodeset used to test instances of ARA API deployed on different operating
@@ -30,20 +27,17 @@
 - nodeset:
     name: ara-multinode
     nodes:
-      - name: fedora-39
-        label: cloud-fedora-39
+      - name: fedora-40
+        label: cloud-fedora-40
       - name: centos-stream-9
         label: cloud-centos-9-stream
-      - name: centos-stream-8
-        label: cloud-centos-8-stream
       # TODO: lacking ubuntu/debian testing coverage because there is no ubuntu image in CI
       #- name: ubuntu-bionic
       #  label: ubuntu-bionic-1vcpu
     groups:
       - name: ara-api-server
         nodes:
-          - fedora-39
+          - fedora-40
           - centos-stream-9
-          - centos-stream-8
           # - ubuntu-bionic
 

--- a/roles/ara_api/tasks/pre-requirements.yaml
+++ b/roles/ara_api/tasks/pre-requirements.yaml
@@ -31,8 +31,6 @@
   block:
     - name: Update apt cache
       command: apt-get update
-      args:
-        warn: false
       when: ansible_facts["os_family"] == "Debian"
 
     - name: Update yum/dnf cache
@@ -41,8 +39,6 @@
         {{ ansible_pkg_mgr }} check-update
       register: yum_update
       failed_when: yum_update['rc'] not in [0, 100]
-      args:
-        warn: false
       when: ansible_facts["os_family"] == "RedHat"
 
     - name: Install required packages

--- a/roles/ara_frontend_nginx/templates/ara-api-ssl.conf.j2
+++ b/roles/ara_frontend_nginx/templates/ara-api-ssl.conf.j2
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name {{ ara_api_fqdn }};
     {% if ara_api_external_auth -%}
     auth_basic "Privileged access";
@@ -25,7 +25,6 @@ server {
     access_log /var/log/nginx/{{ ara_api_fqdn }}_access.log;
     error_log  /var/log/nginx/{{ ara_api_fqdn }}_error.log;
 
-    ssl on;
     ssl_certificate {{ ara_api_frontend_ssl_cert }};
     ssl_certificate_key {{ ara_api_frontend_ssl_key }};
     ssl_session_cache   shared:SSL:10m;


### PR DESCRIPTION
(cherry picked from commit f189ded00eadd75b8c5bbd18fd67fc51b633bafd) @ https://github.com/ansible-community/ara-collection/pull/69